### PR TITLE
Type hint for functors allows using Template_groups.t 

### DIFF
--- a/src/eba_main.eliom
+++ b/src/eba_main.eliom
@@ -21,7 +21,7 @@ module App(M : ParamT) : sig
   module Session : Eba_sigs.Session
     with type group = M.Groups.t
   module Email : Eba_sigs.Email
-  module Page : Eba_sigs.Page
+  module Page : Eba_sigs.Page with module Session = Session
   module Tools : Eba_sigs.Tools
   module Reqm : Eba_sigs.Reqm
   module State : Eba_sigs.State


### PR DESCRIPTION
in `connected_page` function. Related to #7
