### PR TITLE
Generating page content specific to user's role

### DIFF
--- a/src/eba_config.eliom
+++ b/src/eba_config.eliom
@@ -9,6 +9,8 @@ module type Page = sig
 
     method default_error_page :
       'a 'b. 'a -> 'b -> exn -> Eba_shared.Page.page_content Lwt.t
+    method default_denied_page :
+      'a 'b. int64 option -> 'a -> 'b -> Eba_shared.Page.page_content Lwt.t
     method default_connected_error_page :
       'a 'b. int64 option -> 'a -> 'b -> exn -> Eba_shared.Page.page_content Lwt.t
 

--- a/src/eba_config.eliomi
+++ b/src/eba_config.eliomi
@@ -42,6 +42,9 @@ module type Page = sig
     method default_connected_error_page :
       'a 'b. int64 option -> 'a -> 'b -> exn -> Eba_shared.Page.page_content Lwt.t
 
+    method default_denied_page :
+      'a 'b. int64 option -> 'a -> 'b -> Eba_shared.Page.page_content Lwt.t
+
     (** [default_predicate] See NOTE (above) *)
     method default_predicate :
       'a 'b. 'a -> 'b -> bool Lwt.t

--- a/src/eba_default.eliom
+++ b/src/eba_default.eliom
@@ -20,6 +20,10 @@ module Page = struct
     method default_error_page
       : 'a 'b. 'a -> 'b -> exn -> Eba_shared.Page.page_content Lwt.t
       = (fun _ _ _ -> Lwt.return [])
+    method default_denied_page
+      : 'a 'b. int64 option -> 'a -> 'b -> Eba_shared.Page.page_content  Lwt.t
+      = (fun _ _ _ -> Lwt.return [])
+
     method default_connected_error_page
       : 'a 'b. int64 option -> 'a -> 'b -> exn -> Eba_shared.Page.page_content Lwt.t
       = (fun _ _ _ _ -> Lwt.return [])

--- a/src/eba_page.eliom
+++ b/src/eba_page.eliom
@@ -69,27 +69,16 @@ module Make(C : Eba_config.Page)(Session : Eba_sigs.Session) = struct
            ~other:C.config#other_head ())
          (body content))
 
-  let maybe_connected_page
-      ?allow ?deny
-      ~ondenied
-      ~onerror
-      f gp pp =
+  let how_connected_page ?allow ?deny ~onerror f gp pp =
     lwt content =
-      let f_wrapped user gp pp =
-        try_lwt
-          match user with
-          | Some uid -> f uid gp pp
-          | None     -> ondenied gp pp
-        with
-          | exc -> onerror user gp pp exc
-      in
-      try_lwt Session.Opt.connected_fun ?allow ?deny f_wrapped gp pp
+      try_lwt Session.how_connected ?allow ?deny f gp pp
       with
-      | exc -> onerror None gp pp exc
+      | exc -> onerror gp pp exc
     in
     Lwt.return
       (html
          (Eliom_tools.F.head ~title:C.config#title ~css ~js
            ~other:C.config#other_head ())
          (body content))
+
 end

--- a/src/eba_sigs.eliom
+++ b/src/eba_sigs.eliom
@@ -82,6 +82,14 @@ module type Page = sig
     -> (int64 -> 'a -> 'b -> page_content Lwt.t)
     -> 'a -> 'b
     -> page Lwt.t
+
+  val maybe_connected_page :
+       ?allow:Session.group list
+    -> ?deny:Session.group list
+    -> ondenied:('a -> 'b -> page_content Lwt.t)
+    -> onerror:(int64 option -> 'a -> 'b -> exn -> page_content Lwt.t)
+    -> (int64 -> 'a -> 'b -> page_content Lwt.t)
+    -> 'a -> 'b -> page Lwt.t
 end
 
 module type Email = sig

--- a/src/eba_sigs.eliom
+++ b/src/eba_sigs.eliom
@@ -90,13 +90,13 @@ module type Page = sig
     -> 'a -> 'b
     -> page Lwt.t
 
-  val maybe_connected_page :
+  val how_connected_page :
        ?allow:Session.group list
     -> ?deny:Session.group list
-    -> ondenied:('a -> 'b -> page_content Lwt.t)
-    -> onerror:(int64 option -> 'a -> 'b -> exn -> page_content Lwt.t)
-    -> (int64 -> 'a -> 'b -> page_content Lwt.t)
-    -> 'a -> 'b -> page Lwt.t
+    -> onerror:('get -> 'post -> exn -> page_content Lwt.t)
+    -> (Session.conn_mode -> 'get -> 'post -> page_content Lwt.t)
+    -> 'get -> 'post -> page Lwt.t
+
 end
 
 module type Email = sig

--- a/src/eba_sigs.eliom
+++ b/src/eba_sigs.eliom
@@ -37,6 +37,13 @@ module type Session = sig
 
   val get_current_userid : unit -> int64
 
+  type conn_mode = [ `GuestConnected | `GuestDenied | `Denied of int64 | `Allowed of int64 ]
+  val how_connected :
+     ?allow:group list
+  -> ?deny:group list
+  -> (conn_mode -> 'get -> 'post -> 'a Lwt.t)
+  -> 'get -> 'post -> 'a Lwt.t
+
   module Opt : sig
     val connected_fun :
        ?allow:group list

--- a/src/eba_sigs.eliomi
+++ b/src/eba_sigs.eliomi
@@ -146,13 +146,13 @@ module type Page = sig
                        -> (int64 -> 'a -> 'b -> page_content Lwt.t)
                        -> 'a -> 'b
                        -> page Lwt.t
-  val maybe_connected_page :
+
+  val how_connected_page :
        ?allow:Session.group list
     -> ?deny:Session.group list
-    -> ondenied:('a -> 'b -> page_content Lwt.t)
-    -> onerror:(int64 option -> 'a -> 'b -> exn -> page_content Lwt.t)
-    -> (int64 -> 'a -> 'b -> page_content Lwt.t)
-    -> 'a -> 'b -> page Lwt.t
+    -> onerror:('get -> 'post -> exn -> page_content Lwt.t)
+    -> (Session.conn_mode -> 'get -> 'post -> page_content Lwt.t)
+    -> 'get -> 'post -> page Lwt.t
 
 end
 

--- a/src/eba_sigs.eliomi
+++ b/src/eba_sigs.eliomi
@@ -61,6 +61,14 @@ module type Session = sig
     * If there is no user connected, the function raise Not_connected.  *)
   val get_current_userid : unit -> int64
 
+  (* TODO: doc *)
+  type conn_mode = [ `GuestConnected | `GuestDenied | `Denied of int64 | `Allowed of int64 ]
+  val how_connected :
+     ?allow:group list
+  -> ?deny:group list
+  -> (conn_mode -> 'get -> 'post -> 'a Lwt.t)
+  -> 'get -> 'post -> 'a Lwt.t
+
   module Opt : sig
     (** Same as above but instead of raising an Not_connected, the first
       * parameter is wrapped into an option, None tells you that the user

--- a/src/eba_sigs.eliomi
+++ b/src/eba_sigs.eliomi
@@ -130,6 +130,22 @@ module type Page = sig
                        -> (int64 -> 'a -> 'b -> page_content Lwt.t)
                        -> 'a -> 'b
                        -> page Lwt.t
+
+  val connected_page :    ?allow:Session.group list
+                       -> ?deny:Session.group list
+                       -> ?predicate:(int64 -> 'a -> 'b -> bool Lwt.t)
+                       -> ?fallback:(int64 option -> 'a -> 'b -> exn -> page_content Lwt.t)
+                       -> (int64 -> 'a -> 'b -> page_content Lwt.t)
+                       -> 'a -> 'b
+                       -> page Lwt.t
+  val maybe_connected_page :
+       ?allow:Session.group list
+    -> ?deny:Session.group list
+    -> ondenied:('a -> 'b -> page_content Lwt.t)
+    -> onerror:(int64 option -> 'a -> 'b -> exn -> page_content Lwt.t)
+    -> (int64 -> 'a -> 'b -> page_content Lwt.t)
+    -> 'a -> 'b -> page Lwt.t
+
 end
 
 (** Email module : TODO *)

--- a/src/eba_sigs.eliomi
+++ b/src/eba_sigs.eliomi
@@ -139,13 +139,6 @@ module type Page = sig
                        -> 'a -> 'b
                        -> page Lwt.t
 
-  val connected_page :    ?allow:Session.group list
-                       -> ?deny:Session.group list
-                       -> ?predicate:(int64 -> 'a -> 'b -> bool Lwt.t)
-                       -> ?fallback:(int64 option -> 'a -> 'b -> exn -> page_content Lwt.t)
-                       -> (int64 -> 'a -> 'b -> page_content Lwt.t)
-                       -> 'a -> 'b
-                       -> page Lwt.t
 
   val how_connected_page :
        ?allow:Session.group list


### PR DESCRIPTION
I needed recently to generate different content on the same page for different kind of users. I have failed to do this on top of current `connected_page` function (page header for logged inproblem was as like as guest's one, no idea what was wrong), so I have added another one. It studies user's kind and do  one of four decisions:
1. Logged in user when only specific group has access to this page. Moderator, for example.
2. Logged in user without allowed group. Normal user
3. Guest when all logged in users can see this page
4. Guest when only specific groups can see content. It seems that it's good choice for  `Permission_denied` page there.

Do you need this function?
