### PR TITLE
README.md: add dependency to dbm

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If not, start with a simpler template (but you can still use the modules from El
 
 ###<a id="install"></a>Installation
 
-Eliom-base-app depends on dev version of Eliom (branch shared react),
+Eliom-base-app depends on dbm, dev version of Eliom (branch shared react),
 and dev version of tyxml, js_of_ocaml, ojquery, macaque, ocsigen-widgets and reactiveData.
 Use opam to install it, after pinning the github repositories.
 


### PR DESCRIPTION
Without installing that package, ocsigenserver
is built without ocsipersist-dbm.* files.
And in that situation, eliom-base-app
fails as

$ make test.byte
ocsigenserver: ocsipersist:dbm: ...Initialization complete
ocsigenserver: ocsigen:main: Fatal - Findlib package\
eliom.server not found: maybe you forgot <findlib path="..."/>?