### PR TITLE
fix behaviour when multiple use of plain activation key

### DIFF
--- a/src/os_db.ml
+++ b/src/os_db.ml
@@ -22,6 +22,7 @@
 
 exception No_such_resource
 exception Main_email_removal_attempt
+exception Account_already_activated
 
 
 let (>>=) = Lwt.bind

--- a/src/os_db.ml
+++ b/src/os_db.ml
@@ -226,7 +226,7 @@ module User = struct
     email : string;
     validity : int64;
     autoconnect : bool;
-    action : string;
+    action : [ `AccountActivation | `PasswordReset | `Custom of string ];
     data : string;
   }
 
@@ -265,8 +265,12 @@ module User = struct
     >>
 
   let add_activationkey ?(autoconnect=false)
-      ?(action="activation") ?(data="") ?(validity=1L)
+      ?(action=`AccountActivation) ?(data="") ?(validity=1L)
       ~act_key ~userid ~email () =
+    let action = match action with
+      | `AccountActivation -> "activation"
+      | `PasswordReset -> "passwordreset"
+      | `Custom s -> s in
     run_query
      <:insert< $activation_table$ :=
       { userid = $int64:userid$;
@@ -421,7 +425,10 @@ module User = struct
           let email  = t#!email in
           let validity = t#!validity in
           let autoconnect = t#!autoconnect in
-          let action = t#!action in
+          let action = match t#!action with
+            | "activation" -> `AccountActivation
+            | "passwordreset" -> `PasswordReset
+            | c -> `Custom c in
           let data = t#!data in
           let v  = max 0L (Int64.pred validity) in
 	  lwt () = Lwt_Query.query dbh
@@ -476,7 +483,7 @@ module User = struct
            e.userid = u.userid;
            e.email = $string:email$
         >>
-	  
+
 
   let get_users ?pattern () =
     full_transaction_block (fun dbh ->

--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -207,10 +207,10 @@ let activation_handler_common ~akey =
      TODO: do not disconnect users if we relog them with the same userid.
   *)
   try%lwt
-    let%lwt {userid; email; validity; action; data = _; autoconnect} =
+    let%lwt {Os_user.userid; email; validity; action; data = _; autoconnect} =
       Os_user.get_activationkey_info akey in
     let%lwt () =
-      if action = "activation" && validity <= 0L then
+      if action = `AccountActivation && validity <= 0L then
         Lwt.fail Os_db.Account_already_activated
       else Lwt.return_unit in
     let%lwt () =

--- a/src/os_user.eliomi
+++ b/src/os_user.eliomi
@@ -9,7 +9,7 @@ type activationkey_info = {
   email : string;
   validity : int64;
   autoconnect : bool;
-  action : string;
+  action : [ `AccountActivation | `PasswordReset | `Custom of string ];
   data : string;
 }
 
@@ -45,10 +45,11 @@ val emails_of_user : t -> string Lwt.t
 
 val add_activationkey :
   (* by default, an activation key is just an activation key *)
-  ?autoconnect:bool -> (* default: false *)
-  ?action:string -> (* default: "activation" *)
-  ?data:string -> (* default: empty string *)
-  ?validity:int64 -> (* default: 1L *)
+  ?autoconnect:bool -> (** default: false *)
+  ?action:[ `AccountActivation | `PasswordReset | `Custom of string ] ->
+  (** default: `AccountActivation *)
+  ?data:string -> (** default: empty string *)
+  ?validity:int64 -> (** default: 1L *)
   act_key:string -> userid:int64 -> email:string -> unit -> unit Lwt.t
 
 val verify_password : email:string -> password:string -> int64 Lwt.t


### PR DESCRIPTION
- before: reusing an plain activation key leads to an error
- after: reusing an plain activation key just ignores the key
- justification: when an plain activation key has been used before, it
  means that the account was activated. It's okay to just ignore the
  key if it's used again, since the associated action cannot be done
  again anyway, nor can it be undone.

- By "plain activation key", I mean a key which purpose is to activate
  an account. It is the default kind of key. Other kinds of keys
  include, for instance, password reset keys.

	modified:   src/os_db.ml
	modified:   src/os_handlers.eliom