### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,20 @@ modules from Ocsigen-start.
 
 ###<a id="install"></a>Installation
 
-Ocsigen-start depends on Eliom >= 5.0, ojquery (development version),
-Macaque, ocsigen-widgets and reactiveData. You can use OPAM to install
-everything; you need to pin the repositories for ocsigen-widgets,
-ojquery, and Ocsigen-start itself.
+Ocsigen-start has a list of dependencies. All can be installed using opam. Here the commands:
+```
+opam pin add ocsigenserver https://github.com/ocsigen/ocsigenserver.git
+opam pin add js_of_ocaml https://github.com/ocsigen/js_of_ocaml.git
+opam pin add deriving https://github.com/ocsigen/deriving.git
+opam pin add reactiveData https://github.com/ocsigen/reactiveData.git
+opam pin add eliom https://github.com/ocsigen/eliom.git
+opam pin add ocsigen-toolkit https://github.com/ocsigen/ocsigen-toolkit.git
+opam pin add ojquery https://github.com/ocsigen/ojquery.git
+opam pin add ocsigen-widgets https://github.com/ocsigen/ocsigen-widgets.git
+opam pin add ocsigen-start https://github.com/ocsigen/ocsigen-start.git
+```
+
+Ocsigen-widgets depends on the [OCaml binding to ImageMagick C library](https://github.com/besport/ocaml-imagemagick) so you need to install the [C library](http://www.imagemagick.org/script/index.php).
 
 ###<a id="create-your-project"></a>Create your project
 ```

--- a/README.md
+++ b/README.md
@@ -35,18 +35,21 @@ modules from Ocsigen-start.
 
 Ocsigen-start has a list of dependencies. All can be installed using opam. Here the commands:
 ```
-opam pin add ocsigenserver https://github.com/ocsigen/ocsigenserver.git
-opam pin add js_of_ocaml https://github.com/ocsigen/js_of_ocaml.git
-opam pin add deriving https://github.com/ocsigen/deriving.git
-opam pin add reactiveData https://github.com/ocsigen/reactiveData.git
-opam pin add eliom https://github.com/ocsigen/eliom.git
-opam pin add ocsigen-toolkit https://github.com/ocsigen/ocsigen-toolkit.git
-opam pin add ojquery https://github.com/ocsigen/ojquery.git
-opam pin add ocsigen-widgets https://github.com/ocsigen/ocsigen-widgets.git
-opam pin add ocsigen-start https://github.com/ocsigen/ocsigen-start.git
+opam pin add --no-action -y ocsigenserver https://github.com/ocsigen/ocsigenserver.git
+opam pin add --no-action -y js_of_ocaml https://github.com/ocsigen/js_of_ocaml.git
+opam pin add --no-action -y deriving https://github.com/ocsigen/deriving.git
+opam pin add --no-action -y reactiveData https://github.com/ocsigen/reactiveData.git
+opam pin add --no-action -y eliom https://github.com/ocsigen/eliom.git
+opam pin add --no-action -y ocsigen-toolkit https://github.com/ocsigen/ocsigen-toolkit.git
+opam pin add --no-action -y ojquery https://github.com/ocsigen/ojquery.git
+opam pin add --no-action -y ocsigen-widgets https://github.com/ocsigen/ocsigen-widgets.git
+opam pin add --no-action -y ocsigen-start https://github.com/ocsigen/ocsigen-start.git
+opam install ocsigen-start -y
 ```
 
 Ocsigen-widgets depends on the [OCaml binding to ImageMagick C library](https://github.com/besport/ocaml-imagemagick) so you need to install the [C library](http://www.imagemagick.org/script/index.php).
+On Mac OSX, you can install it with Homebrew: `brew install imagemagick`
+On Debian/Ubuntu , you can install it with apt-get: `sudo apt-get install libgraphicsmagick1-dev libmagickcore-dev`
 
 ###<a id="create-your-project"></a>Create your project
 ```


### PR DESCRIPTION
It's more convenient to have to copy-paste the command instead of pinning manually each repository.

I just tried on a fresh installation on Mac OS X.

I don't give the instruction to install ImageMagick because it's done on the website.

I removed the old installation instructions because it was out-dated.