### PR TITLE
sed: BSD compatibility

### DIFF
--- a/template.distillery/Makefile.style
+++ b/template.distillery/Makefile.style
@@ -27,7 +27,7 @@ $(CSSDIR):
 $(DEST): $(LOCAL_CSS) | $(CSSDIR)
 	HASH=`cat $< | md5sum | cut -d ' ' -f 1` && \
 	cp $< $(CSS_PREFIX)_$$HASH.css && \
-	sed -i '1s/^/@charset "UTF-8";/' $(CSS_PREFIX)_$$HASH.css && \
+	sed -i .css '1s/^/@charset "UTF-8";/' $(CSS_PREFIX)_$$HASH.css && \
 	ln -sf $(PROJECT_NAME)_$$HASH.css $@
 # Charset is necessary for iOS.
 # Including it in scss does not work because sass removes it.

--- a/template.distillery/Makefile.style
+++ b/template.distillery/Makefile.style
@@ -27,7 +27,7 @@ $(CSSDIR):
 $(DEST): $(LOCAL_CSS) | $(CSSDIR)
 	HASH=`cat $< | md5sum | cut -d ' ' -f 1` && \
 	cp $< $(CSS_PREFIX)_$$HASH.css && \
-	sed -i .css '1s/^/@charset "UTF-8";/' $(CSS_PREFIX)_$$HASH.css && \
+	sed -i -e '1s/^/@charset "UTF-8";/' $(CSS_PREFIX)_$$HASH.css && \
 	ln -sf $(PROJECT_NAME)_$$HASH.css $@
 # Charset is necessary for iOS.
 # Including it in scss does not work because sass removes it.


### PR DESCRIPTION
sed on Mac OS needs the extension with the option -i.
I tried on a Debian and it's also working.