### PR TITLE
Remove useless lines in the HTML files of the mobile template.

### DIFF
--- a/template.distillery/Makefile.mobile
+++ b/template.distillery/Makefile.mobile
@@ -208,7 +208,6 @@ $(CORDOVAPATH)/www/eliom.html: $(CORDOVAPATH) \
 	CSS_HASH=$$(md5sum $(APPCSS) | cut -d ' ' -f 1) && \
 	sed "s,%%APPNAME%%,$(PROJECT_NAME)_$$JS_HASH,g" mobile/eliom.html.in | \
 	sed "s,%%PROJECTNAME%%,$(PROJECT_NAME),g" | \
-	sed "s,%%CSSNAME%%,$(PROJECT_NAME).css,g" | \
 	sed "s,%%APPSERVER%%,$(APP_SERVER),g" > \
 	$(CORDOVAPATH)/www/eliom.html
 

--- a/template.distillery/mobile!eliom.html.in
+++ b/template.distillery/mobile!eliom.html.in
@@ -11,8 +11,7 @@
     <meta name="viewport" content="user-scalable=no, initial-scale=1,
                        maximum-scale=1, minimum-scale=1,
                        width=device-width">
-    <link rel="stylesheet" type="text/css" href="css/index.css">
-    <link rel="stylesheet" type="text/css" href="css/%%CSSNAME%%">
+    <link rel="stylesheet" type="text/css" href="css/%%PROJECTNAME%%.css">
     <script>
       //<![CDATA[
       var __eliom_server = '%%APPSERVER%%';
@@ -26,7 +25,5 @@
     <script src="%%PROJECTNAME%%.js"></script>
   </head>
   <body>
-    <div class="app blink" id="app-container">
-    </div>
   </body>
 </html>

--- a/template.distillery/mobile!index.html.in
+++ b/template.distillery/mobile!index.html.in
@@ -38,7 +38,6 @@
         <meta name="msapplication-tap-highlight" content="no">
         <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">
         <link rel="stylesheet" type="text/css" href="css/index.css">
-        <!-- <base xmlns="http://www.w3.org/1999/xhtml" href="http://192.168.102.200:8080/" id="eliom_base_elt" /> -->
         <title>%%MOBILE_APP_NAME%%</title>
 
         <script>


### PR DESCRIPTION
This PR aims to remove useless lines in the HTML files of the mobile template.

- Eliom.html.in: remove css/index.css and the div with 'app blink' because it's only index.html  which needs it. Change CSSNAME for PROJECTNAME for the css filename because it replaces with the project name.

- Makefile.mobile: remove replacement of CSSNAME by PROJECTNAME because it was the same rule