### PR TITLE
Remove Ow_log and Ow_icon dependency. 

### DIFF
--- a/src/os_current_user.eliom
+++ b/src/os_current_user.eliom
@@ -36,7 +36,7 @@ let get_current_user () =
   | CU_user a -> a
   | CU_idontknown -> (* Should never happen *) failwith please_use_connected_fun
   | _ ->
-    Ow_log.log "Not connected error in Os_current_user";
+    Firebug.console##(log (Js.string "Not connected error in Os_current_user"));
     raise Os_session.Not_connected
 
 ]

--- a/src/os_userbox.eliom
+++ b/src/os_userbox.eliom
@@ -97,7 +97,7 @@ let reset_tips_service = Os_tips.reset_tips_service
 
   let user_menu user service =
     let but = D.div ~a:[a_class ["os_usermenu_button"]]
-        [Ow_icons.F.config ~a:[a_class ["fa-large"]] ()]
+        [Ot_icons.F.config ~a:[a_class ["fa-large"]] ()]
     in
     let menu = D.div [] in
     ignore


### PR DESCRIPTION
**Still Ow_button.**

Ow_button is used in os_userbox and it's the last ccsigen-widgets dependency. Ow_button is used to create the button to popup the connection box.
Ow_button has some dependencies (Ow_active_set, Ow_base_widgets, etc) and I think it would take too much time to try to extract it in ocsigen-toolkit.
As I will work on the template, I will change it later. I think the template doesn't require the entire interface to Ow_button.