### PR TITLE
make add-android failed because config.xml wasn't in the cordova directory

### DIFF
--- a/template.distillery/Makefile.mobile
+++ b/template.distillery/Makefile.mobile
@@ -45,9 +45,9 @@
 # ).
 # Another solution is to build an Hosted Web App
 # (https://developer.microsoft.com/en-us/windows/bridges/hosted-web-apps). It
-# makes it possible to create easily an application based on your website. You can 
-# also use Windows JavaScript API (no OCaml binding available for the moment) to get
-# access to native components.
+# makes it possible to create easily an application based on your website. You
+# can also use Windows JavaScript API (no OCaml binding available for the
+# moment) to get access to native components.
 # You can create the APPX package (package format for Windows app) by using
 # manifoldjs, even if you are on MacOS X or Linux: http://manifoldjs.com/
 # (contains a video describing the entire process available).
@@ -278,7 +278,7 @@ assets: $(CORDOVAPATH) chcp
 
 # cordova platform rules
 
-$(CORDOVAPATH)/platforms/%: $(CORDOVAPATH)
+$(CORDOVAPATH)/platforms/%: check-app-env assets $(CORDOVAPATH)
 	cd $(CORDOVAPATH) ;\
 	cordova platform add $*
 


### PR DESCRIPTION
**See Important section below. PR #109 is needed !!**

When you create a new eliom project based on os.pgocaml
```
eliom-distillery -name add_platform -template os.pgocaml
```
and run
```
make add-android
```
it fails with
```
cd cordova ;\
cordova platform add android
Error: Current working directory is not a Cordova-based project.
Makefile.mobile:282: recipe for target 'cordova/platforms/android' failed
make: *** [cordova/platforms/android] Error 1
```
It is because the Cordova cli needs a Cordova based project to add the platform. A Cordova based project contains at least a `config.xml`(and other directories) which is not present when using `add-platform` because it's done when using `run-android` (with the rules `assets`). `assets` needs also `check-app-env` as dependency to replace APP_SERVER  in `config.xml` (for chcp).

So now, to add the platform, you need to mention the APP_SERVER and APP_REMOTE variables
```
make add-android APP_SERVER=http://IP_ADDRESS APP_REMOTE=yes
```

### Important

If you added the platform before building it ie:
```
eliom-distillery -name add_platform -template os.pgocaml
cd add_platform
make add-android APP_SERVER=http://IP_ADDRESS APP_REMOTE=yes
make run-android APP_SERVER=http://IP_ADDRESS APP_REMOTE=yes
```
it will fail with:
```
cd cordova ;\
cordova platform add android
Error: Platform android already added.
Makefile.mobile:282: recipe for target 'cordova/platforms/android' failed
make: *** [cordova/platforms/android] Error 1
```
because `run-android`tries to re-add the platform. The PR #109 avoids this error by adding `; true`.