### PR TITLE
From bs Makefile.bs: add db-snapshot rule.

### DIFF
--- a/template.distillery/Makefile.db
+++ b/template.distillery/Makefile.db
@@ -88,11 +88,6 @@ pg_ctl  = $(shell \
 $(PSQL_DIR):
 	-mkdir -p $@
 
-pg_ctl = $(shell \
-           sh -c "which pg_ctl" || \
-           sh -c "which pg_ctlcluster" || \
-           sh -c "if [ -f pg_ctl ]; then (echo ./pg_ctl) else (echo '') fi")
-
 ifeq ($(pg_ctl),)
 $(error "no 'pg_ctl' binary found")
 endif

--- a/template.distillery/Makefile.db
+++ b/template.distillery/Makefile.db
@@ -30,7 +30,19 @@ ELIOMDEP          := $(ENV_PSQL) $(ELIOMDEP)
 # should be the same as ENV_PSQL)
 OCSIGENSERVER     := $(OCSIGENSERVER)
 OCSIGENSERVER.OPT := $(OCSIGENSERVER.OPT)
+
 ## ---------------------------------------------------------------------
+
+##----------------------------------------------------------------------
+
+pg_dump = pg_dump
+
+pg_ctl  = $(shell \
+           sh -c "which pg_ctl" || \
+           sh -c "which pg_ctlcluster" || \
+           sh -c "if [ -f pg_ctl ]; then (echo ./pg_ctl) else (echo '') fi")
+
+##----------------------------------------------------------------------
 
 ## ---------------------------------------------------------------------
 ## Here some rules to easily manage the database.
@@ -69,6 +81,10 @@ OCSIGENSERVER.OPT := $(OCSIGENSERVER.OPT)
 # the database is created locally or globally. By default, the database is
 # local.
 
+##----------------------------------------------------------------------
+
+##----------------------------------------------------------------------
+
 $(PSQL_DIR):
 	-mkdir -p $@
 
@@ -80,7 +96,6 @@ pg_ctl = $(shell \
 ifeq ($(pg_ctl),)
 $(error "no 'pg_ctl' binary found")
 endif
-
 
 ifeq ($(LOCAL),yes)
 
@@ -101,6 +116,11 @@ db-status:
 db-delete:
 	$(pg_ctl) -D $(PSQL_DIR) -l $(PSQL_LOG) stop || true
 	rm -rf $(PSQL_DIR)
+
+db-snapshot:
+	@echo "# Creating $(DB_SNAPSHOT)"
+	$(ENV_PSQL) $(pg_dump) --clean --create --no-owner --encoding=utf8 \
+        $(DB_NAME) | gzip > $(DB_SNAPSHOT)
 
 else
 

--- a/template.distillery/Makefile.db
+++ b/template.distillery/Makefile.db
@@ -37,10 +37,15 @@ OCSIGENSERVER.OPT := $(OCSIGENSERVER.OPT)
 
 pg_dump = pg_dump
 
-pg_ctl  = $(shell \
-           sh -c "which pg_ctl" || \
-           sh -c "which pg_ctlcluster" || \
-           sh -c "if [ -f pg_ctl ]; then (echo ./pg_ctl) else (echo '') fi")
+# Rule to get the pg_ctl binary.
+ifeq ($(shell sh -c "which psql" | echo $?),'0')
+$(error "PostgreSQL is not installed")
+else
+PSQL_VERSION := $(shell psql --version | cut -d' ' -f 3 | cut -d'.' -f 1-2)
+pg_ctl       := $(shell \
+                  sh -c "which pg_ctl" || \
+                  sh -c "echo /usr/lib/postgresql/$(PSQL_VERSION)/bin/pg_ctl")
+endif
 
 ##----------------------------------------------------------------------
 
@@ -87,10 +92,6 @@ pg_ctl  = $(shell \
 
 $(PSQL_DIR):
 	-mkdir -p $@
-
-ifeq ($(pg_ctl),)
-$(error "no 'pg_ctl' binary found")
-endif
 
 ifeq ($(LOCAL),yes)
 

--- a/template.distillery/Makefile.options
+++ b/template.distillery/Makefile.options
@@ -151,6 +151,10 @@ DB_PASSWORD           := ""
 ## in Makefile.db) to update the database.
 PSQL_FILE             := $(DB_NAME).sql
 
+## The filename for the database snapshot. This variable is used
+## by 'db-snapshot'.
+DB_SNAPSHOT           := %%%PROJECT_NAME%%%-$$(date '+%Y%m%d%H%M%S').sql.gz
+
 ## Choose if the database will be installed locally or globally
 # - yes: will create the database in the $(TEST_PREFIX)/db (which has the value
 #   'local' by default).


### PR DESCRIPTION
- Use DB_SNAPSHOT instead of DBSNAPSHOT and put this variable in Makefile.options.
- Use a variable for pg_dump.

### Makefile.db reorganisation
- Move pg_dump and pg_ctl at the top (because all variables must be on the top).
- Remove an useless empty new line.