### PR TITLE
Use a type Os_user.id (equivalent to int64) instead of int64 directly.

### DIFF
--- a/src/os_current_user.eliomi
+++ b/src/os_current_user.eliomi
@@ -2,11 +2,11 @@
 [%%shared.start]
 
 val get_current_user : unit -> Os_user.t
-val get_current_userid : unit -> int64
+val get_current_userid : unit -> Os_user.id
 
 module Opt : sig
   val get_current_user : unit -> Os_user.t option
-  val get_current_userid : unit -> int64 option
+  val get_current_userid : unit -> Os_user.id option
 end
 
 [%%client.start]

--- a/src/os_group.mli
+++ b/src/os_group.mli
@@ -58,13 +58,13 @@ val group_of_name : string -> t Lwt.t
 *)
 
 (** Insert a user to a group. *)
-val add_user_in_group : group:t -> userid:int64 -> unit Lwt.t
+val add_user_in_group : group:t -> userid:Os_user.id -> unit Lwt.t
 
 (** Remove a user from a group. *)
-val remove_user_in_group : group:t -> userid:int64 -> unit Lwt.t
+val remove_user_in_group : group:t -> userid:Os_user.id -> unit Lwt.t
 
 (** Does user belong to a group? *)
-val in_group : group:t -> userid:int64 -> bool Lwt.t
+val in_group : group:t -> userid:Os_user.id -> bool Lwt.t
 
 (** Returns all the groups of the database. *)
 val all : unit -> t list Lwt.t

--- a/src/os_handlers.eliomi
+++ b/src/os_handlers.eliomi
@@ -23,10 +23,10 @@ val forgot_password_handler :
 val preregister_handler' :
   unit -> string -> unit Lwt.t
 
-val set_password_handler' : int64 -> unit -> string * string -> unit Lwt.t
+val set_password_handler' : Os_user.id -> unit -> string * string -> unit Lwt.t
 
 val set_personal_data_handler' :
-  int64 -> unit -> (string * string) * (string * string) -> unit Lwt.t
+  Os_user.id -> unit -> (string * string) * (string * string) -> unit Lwt.t
 
 [%%client.start]
 

--- a/src/os_notif.eliomi
+++ b/src/os_notif.eliomi
@@ -51,7 +51,7 @@ sig
   val unlisten : A.key -> unit
 
   (** Make a user stop listening on data [key] *)
-  val unlisten_user : userid:int64 -> A.key -> unit
+  val unlisten_user : userid:Os_user.id -> A.key -> unit
 
   (** Call [notify id f] to send a notification to all clients currently
       listening on data [key]. The notification is build using function [f],

--- a/src/os_page.eliom
+++ b/src/os_page.eliom
@@ -57,12 +57,12 @@ module type PAGE = sig
     Html_types.body_content Eliom_content.Html.elt list Lwt.t
   val default_error_page_full : ('a -> 'b -> exn -> content Lwt.t) option
   val default_connected_error_page :
-    int64 option -> 'a -> 'b -> exn ->
+    Os_user.id option -> 'a -> 'b -> exn ->
     Html_types.body_content Eliom_content.Html.elt list Lwt.t
   val default_connected_error_page_full :
-    (int64 option -> 'a -> 'b -> exn -> content Lwt.t) option
+    (Os_user.id option -> 'a -> 'b -> exn -> content Lwt.t) option
   val default_predicate : 'a -> 'b -> bool Lwt.t
-  val default_connected_predicate : int64 option -> 'a -> 'b -> bool Lwt.t
+  val default_connected_predicate : Os_user.id option -> 'a -> 'b -> bool Lwt.t
 end
 
 module Default_config = struct
@@ -244,7 +244,7 @@ module Make(C : PAGE) = struct
         ?(predicate = C.default_connected_predicate)
         ?(fallback = default_connected_error_page)
         f gp pp =
-      let f_wrapped (uid_o : int64 option) gp pp =
+      let f_wrapped (uid_o : Os_user.id option) gp pp =
         try%lwt
           let%lwt b = predicate uid_o gp pp in
           if b then

--- a/src/os_page.eliomi
+++ b/src/os_page.eliomi
@@ -79,19 +79,19 @@ module type PAGE = sig
 
   (** Default error page for connected pages. *)
   val default_connected_error_page :
-    int64 option -> 'a -> 'b -> exn ->
+    Os_user.id option -> 'a -> 'b -> exn ->
     Html_types.body_content Eliom_content.Html.elt list Lwt.t
 
   (** Default error page for connected pages (with custom headers and
       title). *)
   val default_connected_error_page_full :
-    (int64 option -> 'a -> 'b -> exn -> content Lwt.t) option
+    (Os_user.id option -> 'a -> 'b -> exn -> content Lwt.t) option
 
   (** Default predicate. *)
   val default_predicate : 'a -> 'b -> bool Lwt.t
 
   (** Default predicate for connected pages. *)
-  val default_connected_predicate : int64 option -> 'a -> 'b -> bool Lwt.t
+  val default_connected_predicate : Os_user.id option -> 'a -> 'b -> bool Lwt.t
 
 end
 
@@ -132,11 +132,11 @@ module Make (C : PAGE) : sig
     val connected_page :
       ?allow:Os_group.t list ->
       ?deny:Os_group.t list ->
-      ?predicate:(int64 option -> 'a -> 'b -> bool Lwt.t) ->
-      ?fallback:(int64 option -> 'a -> 'b -> exn ->
+      ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
+      ?fallback:(Os_user.id option -> 'a -> 'b -> exn ->
                  Html_types.body_content Eliom_content.Html.elt
                    list Lwt.t) ->
-      (int64 option -> 'a -> 'b ->
+      (Os_user.id option -> 'a -> 'b ->
        Html_types.body_content Eliom_content.Html.elt list Lwt.t) ->
       ('a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t)
 
@@ -146,9 +146,9 @@ module Make (C : PAGE) : sig
     val connected_page_full :
       ?allow:Os_group.t list ->
       ?deny:Os_group.t list ->
-      ?predicate:(int64 option -> 'a -> 'b -> bool Lwt.t) ->
-      ?fallback:(int64 option -> 'a -> 'b -> exn -> content Lwt.t) ->
-      (int64 option -> 'a -> 'b -> content Lwt.t) ->
+      ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
+      ?fallback:(Os_user.id option -> 'a -> 'b -> exn -> content Lwt.t) ->
+      (Os_user.id option -> 'a -> 'b -> content Lwt.t) ->
       ('a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t)
   end
 
@@ -158,11 +158,11 @@ module Make (C : PAGE) : sig
   val connected_page :
        ?allow:Os_group.t list
     -> ?deny:Os_group.t list
-    -> ?predicate:(int64 option -> 'a -> 'b -> bool Lwt.t)
-    -> ?fallback:(int64 option -> 'a -> 'b -> exn ->
+    -> ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t)
+    -> ?fallback:(Os_user.id option -> 'a -> 'b -> exn ->
                   Html_types.body_content Eliom_content.Html.elt list
                     Lwt.t)
-    -> (int64 -> 'a -> 'b ->
+    -> (Os_user.id -> 'a -> 'b ->
         Html_types.body_content Eliom_content.Html.elt list Lwt.t)
     -> 'a -> 'b
     -> Html_types.html Eliom_content.Html.elt Lwt.t
@@ -174,8 +174,8 @@ module Make (C : PAGE) : sig
   val connected_page_full :
     ?allow:Os_group.t list ->
     ?deny:Os_group.t list ->
-    ?predicate:(int64 option -> 'a -> 'b -> bool Lwt.t) ->
-    ?fallback:(int64 option -> 'a -> 'b -> exn -> content Lwt.t) ->
-    (int64 -> 'a -> 'b -> content Lwt.t) ->
+    ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
+    ?fallback:(Os_user.id option -> 'a -> 'b -> exn -> content Lwt.t) ->
+    (Os_user.id -> 'a -> 'b -> content Lwt.t) ->
     ('a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t)
 end

--- a/src/os_session.eliomi
+++ b/src/os_session.eliomi
@@ -30,15 +30,15 @@ val on_start_process : (unit -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done
     when the process starts in connected mode, or when the user logs in *)
-val on_start_connected_process : (int64 -> unit Lwt.t) -> unit
+val on_start_connected_process : (Os_user.id -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done at each connected request.
     The function takes the user id as parameter. *)
-val on_connected_request : (int64 -> unit Lwt.t) -> unit
+val on_connected_request : (Os_user.id -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done just after opening a session
     The function takes the user id as parameter. *)
-val on_open_session : (int64 -> unit Lwt.t) -> unit
+val on_open_session : (Os_user.id -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done just before closing the session *)
 val on_pre_close_session : (unit -> unit Lwt.t) -> unit
@@ -51,7 +51,7 @@ val on_request : (unit -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done just for each denied request.
     The function takes the user id as parameter, if some user is connected. *)
-val on_denied_request : (int64 option -> unit Lwt.t) -> unit
+val on_denied_request : (Os_user.id option -> unit Lwt.t) -> unit
 
 
 (** Scopes that are independant from user connection.
@@ -76,7 +76,7 @@ exception Permission_denied
     argument [expire] to true, the session will expire when the browser
     exits.
 *)
-val connect : ?expire:bool -> int64 -> unit Lwt.t
+val connect : ?expire:bool -> Os_user.id -> unit Lwt.t
 
 (** Close a session by discarding server side states for current browser
     (session and session group), current client process (tab) and current
@@ -106,48 +106,48 @@ val disconnect : unit -> unit Lwt.t
 val connected_fun :
   ?allow:Os_group.t list ->
   ?deny:Os_group.t list ->
-  ?deny_fun:(int64 option -> 'c Lwt.t) ->
-  (int64 -> 'a -> 'b -> 'c Lwt.t) ->
+  ?deny_fun:(Os_user.id option -> 'c Lwt.t) ->
+  (Os_user.id -> 'a -> 'b -> 'c Lwt.t) ->
   ('a -> 'b -> 'c Lwt.t)
 
 (** Wrapper for server functions (see {!connected_fun}). *)
 val connected_rpc :
   ?allow:Os_group.t list ->
   ?deny:Os_group.t list ->
-  ?deny_fun:(int64 option -> 'b Lwt.t) ->
-  (int64 -> 'a -> 'b Lwt.t) ->
+  ?deny_fun:(Os_user.id option -> 'b Lwt.t) ->
+  (Os_user.id -> 'a -> 'b Lwt.t) ->
   ('a -> 'b Lwt.t)
 
 (** Wrapper for server functions when you do not not need userid. *)
 val connected_wrapper :
   ?allow:Os_group.t list ->
   ?deny:Os_group.t list ->
-  ?deny_fun:(int64 option -> 'b Lwt.t) ->
+  ?deny_fun:(Os_user.id option -> 'b Lwt.t) ->
   ('a -> 'b Lwt.t) ->
   ('a -> 'b Lwt.t)
 
 module Opt : sig
 
   (** Same as {!connected_fun} but instead of failing in case the user is
-      not connected, the function given as parameter takes an [int64 option]
-      for user id.
+      not connected, the function given as parameter takes an [Os_user.id
+      option] for user id.
   *)
   val connected_fun :
     ?allow:Os_group.t list ->
     ?deny:Os_group.t list ->
-    ?deny_fun:(int64 option -> 'c Lwt.t) ->
-    (int64 option -> 'a -> 'b -> 'c Lwt.t) ->
+    ?deny_fun:(Os_user.id option -> 'c Lwt.t) ->
+    (Os_user.id option -> 'a -> 'b -> 'c Lwt.t) ->
     ('a -> 'b -> 'c Lwt.t)
 
   (** Same as {!connected_rpc} but instead of failing in case the user is
-      not connected, the function given as parameter takes an [int64 option]
-      for user id.
+      not connected, the function given as parameter takes an [Os_user.id
+      option] for user id.
   *)
   val connected_rpc :
     ?allow:Os_group.t list ->
     ?deny:Os_group.t list ->
-    ?deny_fun:(int64 option -> 'b Lwt.t) ->
-    (int64 option -> 'a -> 'b Lwt.t) ->
+    ?deny_fun:(Os_user.id option -> 'b Lwt.t) ->
+    (Os_user.id option -> 'a -> 'b Lwt.t) ->
     ('a -> 'b Lwt.t)
 
 end
@@ -156,4 +156,4 @@ end
 (**/**)
 [%%client.start]
    (** internal. Do not use *)
-val get_current_userid_o : (unit -> int64 option) ref
+val get_current_userid_o : (unit -> Os_user.id option) ref

--- a/src/os_user.eliom
+++ b/src/os_user.eliom
@@ -4,13 +4,19 @@
 
 open Eliom_content.Html.F
 
-exception Already_exists of int64
-exception No_such_user
+[%%shared
+  type id = int64 [@@deriving json]
+]
+
+[%%server
+  exception Already_exists of id
+  exception No_such_user
+]
 
 [%%shared
   (** The type which represents a user. *)
   type t = {
-    userid : int64;
+    userid : id;
     fn : string;
     ln : string;
     avatar : string option;
@@ -60,7 +66,7 @@ include Os_db.User
    during the request. *)
 module MCache = Os_request_cache.Make(
 struct
-  type key = int64
+  type key = id
   type value = t * bool
 
   let compare = compare

--- a/src/os_user.eliomi
+++ b/src/os_user.eliomi
@@ -1,11 +1,15 @@
-exception Already_exists of int64
+[%%shared.start]
+type id = int64 [@@deriving json]
+
+[%%server.start]
+exception Already_exists of id
 exception No_such_user
 
 (** Has user set its password? *)
-val password_set : int64 -> bool Lwt.t
+val password_set : id -> bool Lwt.t
 
 type activationkey_info = {
-  userid : int64;
+  userid : id;
   email : string;
   validity : int64;
   autoconnect : bool;
@@ -16,14 +20,14 @@ type activationkey_info = {
 [%%shared.start]
   (** The type which represents a user. *)
 type t = {
-    userid : int64;
+    userid : id;
     fn : string;
     ln : string;
     avatar : string option;
   } [@@deriving json]
 
 
-val userid_of_user : t -> int64
+val userid_of_user : t -> id
 val firstname_of_user : t -> string
 val lastname_of_user : t -> string
 val avatar_of_user : t -> string option
@@ -50,13 +54,13 @@ val add_activationkey :
   (** default: `AccountActivation *)
   ?data:string -> (** default: empty string *)
   ?validity:int64 -> (** default: 1L *)
-  act_key:string -> userid:int64 -> email:string -> unit -> unit Lwt.t
+  act_key:string -> userid:id -> email:string -> unit -> unit Lwt.t
 
-val verify_password : email:string -> password:string -> int64 Lwt.t
+val verify_password : email:string -> password:string -> id Lwt.t
 
 (** returns user information.
     Results are cached in memory during page generation. *)
-val user_of_userid : int64 -> t Lwt.t
+val user_of_userid : id -> t Lwt.t
 
 val get_activationkey_info : string -> activationkey_info Lwt.t
 (** Retrieve the data corresponding to an activation key, each
@@ -65,16 +69,16 @@ val get_activationkey_info : string -> activationkey_info Lwt.t
     you to adapt the actions according to the value of validity!
     Raises [Os_db.No_such_resource] if the activation key is not found. *)
 
-val userid_of_email : string -> int64 Lwt.t
+val userid_of_email : string -> id Lwt.t
 
 (** Retrieve e-mails from user id. *)
-val emails_of_userid : int64 -> string list Lwt.t
+val emails_of_userid : id -> string list Lwt.t
 
 (** Retrieve the main e-mail of a user. *)
 val email_of_user : t -> string Lwt.t
 
 (** Retrieve the main e-mail from user id. *)
-val email_of_userid : int64 -> string Lwt.t
+val email_of_userid : id -> string Lwt.t
 
 (** Retrieve e-mails of a user. *)
 val emails_of_user : t -> string list Lwt.t
@@ -90,16 +94,16 @@ val create :
 (** Update the informations of a user. *)
 val update :
   ?password:string -> ?avatar:string ->
-  firstname:string -> lastname:string -> int64 -> unit Lwt.t
+  firstname:string -> lastname:string -> id -> unit Lwt.t
 
 (** Another version of [update] using a type [t] instead of labels. *)
 val update' : ?password:string -> t -> unit Lwt.t
 
 (** Update the password only *)
-val update_password : string -> int64 -> unit Lwt.t
+val update_password : string -> id -> unit Lwt.t
 
 (** Update the avatar only *)
-val update_avatar : string -> int64 -> unit Lwt.t
+val update_avatar : string -> id -> unit Lwt.t
 
 (** Check wether or not a user exists *)
 val is_registered : string -> bool Lwt.t
@@ -125,21 +129,21 @@ val all : ?limit:int64 -> unit -> string list Lwt.t
     by user, and as third parameter the hash found in database.
 *)
 val set_pwd_crypt_fun : (string -> string) *
-                        (int64 -> string -> string -> bool) -> unit
+                        (id -> string -> string -> bool) -> unit
 
 (** Removes the email [email] from the user with the id [userid],
     if the email is registered as the main email for the user it fails
     with the exception [Main_email_removal_attempt].
 *)
-val remove_email_from_user : userid:int64 -> email:string -> unit Lwt.t
+val remove_email_from_user : userid:id -> email:string -> unit Lwt.t
 
 (** Returns whether for a user designated by its id the given email has been
     validated. *)
-val email_is_validated : userid:int64 -> email:string -> bool Lwt.t
+val email_is_validated : userid:id -> email:string -> bool Lwt.t
 
 (** Returns whether an email is the  main email registered for a
     given user designated by its id. *)
-val is_main_email : userid:int64 -> email:string -> bool Lwt.t
+val is_main_email : userid:id -> email:string -> bool Lwt.t
 
 (** Sets the main email for a user with the id [userid] as the email [email]. *)
-val update_main_email : userid:int64 -> email:string -> unit Lwt.t
+val update_main_email : userid:id -> email:string -> unit Lwt.t

--- a/src/os_userbox.eliomi
+++ b/src/os_userbox.eliomi
@@ -37,7 +37,7 @@ val upload_pic_link :
      * Html_types.button_content_fun Eliom_content.Html.D.Raw.elt list
   -> (unit -> unit) Eliom_client_value.t
   -> uploader
-  -> int64
+  -> Os_user.id
   -> [> `A of Html_types.a_content ] Eliom_content.Html.D.Raw.elt
 
 (** Link to start to see the help from the begining.


### PR DESCRIPTION
To have more readable error outputs.

I use Os_user.id instead of Os_user.userid because the module name is enough to distinguish.

See also #134 for groups.