### PR TITLE
Use a type Os_group.id instead of int64 directly.

### DIFF
--- a/src/os_group.ml
+++ b/src/os_group.ml
@@ -22,10 +22,11 @@
 
 exception No_such_group
 
+type id = int64
 
 (** The type of a group *)
 type t = {
-  id : int64;
+  id : id;
   name : string;
   desc : string option;
 }

--- a/src/os_group.mli
+++ b/src/os_group.mli
@@ -34,10 +34,12 @@ exception No_such_group
 
 *)
 
+type id = int64
+
 (** The type of a group *)
 type t
 
-val id_of_group : t -> int64
+val id_of_group : t -> id
 val name_of_group : t -> string
 val desc_of_group : t -> string option
 


### PR DESCRIPTION
To have more readable error outputs. See also #133 