### PR TITLE
Icons

### DIFF
--- a/template.distillery/PROJECT_NAME_icons.eliom
+++ b/template.distillery/PROJECT_NAME_icons.eliom
@@ -1,24 +1,37 @@
+(** This module defines an interface to create icons HTML element with
+ * predefined style/value. It is supposed "Font Awesome" icons are used by
+ * default (fa CSS class is added when using [icon classes]).
+ * See http://fontawesome.io/ for more information and for the complete list of
+ * CSS classes values.
+ *)
+
 [%%shared.start]
 
 module Make(A : module type of Eliom_content.Html.F) = struct
 
-  let icon classes ?(class_=[]) () =
-    A.i ~a:[A.a_class ("fa"::classes@class_)] []
+  (** [icon classes] create an icon HTML attribute with "fa" and [classes]
+   * as CSS classes.
+   * The optional parameter is at the end to be able to add other CSS classes
+   * with predefined icons.
+   *)
+  let icon classes
+      ?(a = ([] : Html_types.i_attrib Eliom_content.Html.attrib list)) () =
+    A.i ~a:(A.a_class ("fa" :: classes) :: a) []
 
-  (* Add your own icons here *)
+  (* Add your own icons here. See http://fontawesome.io/icons/ for the complete
+   * list of CSS classes available by default.
+   *)
 
-  (* Example:
-     let user = icon ["fa-user"; "fa-fw"]
-  *)
+  (* Example for the user icon:
+   *  let user = icon ["fa-user"; "fa-fw"]
+   *)
 
 end
 
 module F = struct
-  include Ow_icons.F
   include Make(Eliom_content.Html.F)
 end
 
 module D = struct
-  include Ow_icons.D
   include Make(Eliom_content.Html.D)
 end

--- a/template.distillery/PROJECT_NAME_icons.eliom
+++ b/template.distillery/PROJECT_NAME_icons.eliom
@@ -9,9 +9,10 @@
 
 module Make(A : module type of Eliom_content.Html.F) = struct
 
-  (** [icon classes] create an icon HTML attribute with "fa" and [classes]
-   * as CSS classes.
-   * The optional parameter is at the end to be able to add other CSS classes
+  (** [icon classes ~a:other_css_classes ()] create an icon HTML attribute with
+   * "fa" and [classes] as CSS classes. The HTML tag "i" is used because it
+   * became the standard for icons.
+   * The optional parameter ~a is at the end to be able to add other CSS classes
    * with predefined icons.
    *)
   let icon classes
@@ -28,10 +29,6 @@ module Make(A : module type of Eliom_content.Html.F) = struct
 
 end
 
-module F = struct
-  include Make(Eliom_content.Html.F)
-end
+module F = Make(Eliom_content.Html.F)
 
-module D = struct
-  include Make(Eliom_content.Html.D)
-end
+module D = Make(Eliom_content.Html.D)


### PR DESCRIPTION
- Remove Ow_icons dependency.
- Add comments.
- ~~I also removed the `class_` parameter because it seems to do the same job than classes.~~

I didn't merge `Ot_icons` and `PROJECT_NAME_icons.eliom` and I didn't include `Ot_icons` in `PROJECT_NAME_icons.eliom` because they define two different families of icons: one with OT, the other with Font Awesome.