### PR TITLE
Remove warning about types inference.

### DIFF
--- a/src/os_msg.eliom
+++ b/src/os_msg.eliom
@@ -33,19 +33,23 @@ let%client msgbox () =
     Dom.appendChild Dom_html.document##.body b;
     b
 
-let%shared msg ?(level = `Err) ?(duration = 2.) ?(onload=false) msg =
+let%shared msg
+  ?(level = `Err)
+  ?(duration = 2.)
+  ?(onload=false)
+  (message : string) =
   ignore [%client (
     let c = if ~%level = `Msg then [] else ["os_err"] in
-    Eliom_lib.debug "%s" ~%msg;
-    let msg = To_dom.of_p (D.p ~a:[a_class c] [pcdata ~%msg]) in
+    Eliom_lib.debug "%s" ~%message;
+    let message_dom = To_dom.of_p (D.p ~a:[a_class c] [pcdata ~%message]) in
     let msgbox = msgbox () in
     Lwt.async (fun () ->
       let%lwt () =
         if ~%onload then Eliom_client.lwt_onload () else Lwt.return ()
       in
-      Dom.appendChild msgbox msg;
+      Dom.appendChild msgbox message_dom;
       let%lwt () = Lwt_js.sleep ~%duration in
-      Dom.removeChild msgbox msg;
+      Dom.removeChild msgbox message_dom;
       Lwt.return ())
     : unit)]
 

--- a/src/os_tools.eliom
+++ b/src/os_tools.eliom
@@ -47,7 +47,8 @@
 let%shared popup_button
     ~button_name
     ?(button_class = ["os_popup_button"])
-    ~popup_content
+    ~(popup_content : (unit -> [< Html_types.div_content ]
+    Eliom_content.Html.elt Lwt.t))
     = Eliom_content.Html.D.(
       let button =
         button ~a:[a_class button_class] [pcdata button_name]

--- a/src/os_userbox.eliom
+++ b/src/os_userbox.eliom
@@ -46,10 +46,18 @@ let%shared upload_pic_link
     ?(a = [])
     ?(content=[pcdata "Change profile picture"])
     ?(crop = Some 1.)
-    ?(input= [], [])
-    ?(submit= [], [pcdata "Submit"])
-    close
-    service
+    ?(input :
+      Html_types.label_attrib Eliom_content.Html.D.Raw.attrib list
+      * Html_types.label_content_fun Eliom_content.Html.D.Raw.elt list
+      = [], []
+    )
+    ?(submit :
+      Html_types.button_attrib Eliom_content.Html.D.Raw.attrib list
+      * Html_types.button_content_fun Eliom_content.Html.D.Raw.elt list
+      = [], [pcdata "Submit"]
+    )
+    (close : (unit -> unit) Eliom_client_value.t)
+    (service : uploader)
     userid =
   let content = (content
                  : Html_types.a_content Eliom_content.Html.D.Raw.elt list) in
@@ -124,7 +132,7 @@ let%shared user_menu user service =
 
 let%client set_user_menu f = user_menu_fun := f
 
-let%shared connected_user_box user service =
+let%shared connected_user_box user (service : uploader) =
   let username = Os_view.username user in
   D.div ~a:[a_id "os-user-box"] [
     Os_view.avatar user;

--- a/src/os_view.eliom
+++ b/src/os_view.eliom
@@ -109,11 +109,13 @@ let%shared information_form ?a
          Lwt_js_events.(async (fun () ->
            inputs pass2 (fun _ _ ->
              if (Js.to_string pass1##.value <> Js.to_string pass2##.value)
-             then (Js.Unsafe.coerce pass2)##(setCustomValidity
-                 ("Passwords do not match"))
-             else (Js.Unsafe.coerce pass2)##(setCustomValidity (""));
-             Lwt.return ())))
-       : unit)]
+             then
+               (Js.Unsafe.coerce pass2)##(setCustomValidity
+               ("Passwords do not match"))
+             else (Js.Unsafe.coerce pass2)##(setCustomValidity (""))
+           )
+         )
+       ) : unit)]
        in
        [
          Form.input


### PR DESCRIPTION
:gift: I heard @balat complain about these warnings and he wanted to remove it :gift:.
I agree it's better without them.
Still warnings about the cmx files.

The code is ugly but it still readable.