### PR TITLE
Remove simple quote at the end of some handlers and services.

### DIFF
--- a/src/os_db.mli
+++ b/src/os_db.mli
@@ -22,6 +22,7 @@
 exception No_such_resource
 exception Main_email_removal_attempt
 exception Account_already_activated
+exception Account_not_activated
 
 val init :
   ?host:string ->

--- a/src/os_handlers.eliomi
+++ b/src/os_handlers.eliomi
@@ -39,12 +39,12 @@ val forgot_password_handler :
     Eliom_service.t ->
   unit -> string -> unit Lwt.t
 
-val preregister_handler' :
+val preregister_handler :
   unit -> string -> unit Lwt.t
 
-val set_password_handler' : Os_user.id -> unit -> string * string -> unit Lwt.t
+val set_password_handler : Os_user.id -> unit -> string * string -> unit Lwt.t
 
-val set_personal_data_handler' :
+val set_personal_data_handler :
   Os_user.id -> unit -> (string * string) * (string * string) -> unit Lwt.t
 
 [%%client.start]

--- a/src/os_services.eliom
+++ b/src/os_services.eliom
@@ -28,7 +28,7 @@ let%server main_service =
     ~meth:(Eliom_service.Get Eliom_parameter.unit)
     ()
 
-let%server preregister_service' =
+let%server preregister_service =
   Eliom_service.create
     ~name:"preregister_service"
     ~path:Eliom_service.No_path
@@ -48,7 +48,7 @@ let%server forgot_password_service =
           Eliom_parameter.string "email"))
     ()
 
-let%server set_personal_data_service' =
+let%server set_personal_data_service =
   Eliom_service.create
     ~name:"set_data"
     ~path:Eliom_service.No_path
@@ -59,7 +59,7 @@ let%server set_personal_data_service' =
           (string "password"  ** string "password2")))
     ()
 
-let%server sign_up_service' =
+let%server sign_up_service =
   Eliom_service.create
     ~name:"sign_up"
     ~path:Eliom_service.No_path
@@ -96,7 +96,7 @@ let%server activation_service =
     ~meth:(Eliom_service.Get (Eliom_parameter.string "activationkey"))
     ()
 
-let%server set_password_service' =
+let%server set_password_service =
   Eliom_service.create
     ~name:"set_password"
     ~path:Eliom_service.No_path
@@ -115,12 +115,12 @@ let%server add_email_service = Eliom_service.create
   )) ()
 
 let%client main_service = ~%main_service
-let%client preregister_service' = ~%preregister_service'
+let%client preregister_service = ~%preregister_service
 let%client forgot_password_service = ~%forgot_password_service
-let%client set_personal_data_service' = ~%set_personal_data_service'
-let%client sign_up_service' = ~%sign_up_service'
+let%client set_personal_data_service = ~%set_personal_data_service
+let%client sign_up_service = ~%sign_up_service
 let%client connect_service = ~%connect_service
 let%client disconnect_service = ~%disconnect_service
 let%client activation_service = ~%activation_service
-let%client set_password_service' = ~%set_password_service'
+let%client set_password_service = ~%set_password_service
 let%client add_email_service = ~%add_email_service

--- a/src/os_services.eliomi
+++ b/src/os_services.eliomi
@@ -36,7 +36,7 @@ val main_service :
     Eliom_service.non_ocaml
   ) Eliom_service.t
 
-val preregister_service' :
+val preregister_service :
   (
     unit,
     string,
@@ -66,7 +66,7 @@ val forgot_password_service :
     Eliom_service.non_ocaml
   ) Eliom_service.t
 
-val set_personal_data_service' :
+val set_personal_data_service :
   (
     unit,
     (string * string) * (string * string),
@@ -82,7 +82,7 @@ val set_personal_data_service' :
     Eliom_service.non_ocaml
   ) Eliom_service.t
 
-val sign_up_service' :
+val sign_up_service :
   (
     unit,
     string,
@@ -143,7 +143,7 @@ val activation_service :
     Eliom_service.non_ocaml
   ) Eliom_service.t
 
-val set_password_service' :
+val set_password_service :
   (
     unit,
     string * string,

--- a/src/os_user.eliom
+++ b/src/os_user.eliom
@@ -140,7 +140,7 @@ let update ?password ?avatar ~firstname ~lastname userid =
   MCache.reset userid;
   Lwt.return ()
 
-let update' ?password t =
+let update ?password t =
   update ?password ?avatar:t.avatar ~firstname:t.fn ~lastname:t.ln t.userid
 
 let update_password password userid =

--- a/src/os_user.eliomi
+++ b/src/os_user.eliomi
@@ -117,7 +117,7 @@ val update :
   firstname:string -> lastname:string -> id -> unit Lwt.t
 
 (** Another version of [update] using a type [t] instead of labels. *)
-val update' : ?password:string -> t -> unit Lwt.t
+val update : ?password:string -> t -> unit Lwt.t
 
 (** Update the password only *)
 val update_password : string -> id -> unit Lwt.t

--- a/src/os_userbox.eliom
+++ b/src/os_userbox.eliom
@@ -104,7 +104,7 @@ let%shared reset_tips_link close =
 let%shared user_menu_ close user service =
   [
     p [pcdata "Change your password:"];
-    Os_view.password_form ~service:Os_services.set_password_service' ();
+    Os_view.password_form ~service:Os_services.set_password_service ();
     hr ();
     upload_pic_link close service (Os_user.userid_of_user user);
     hr ();

--- a/src/os_view.eliom
+++ b/src/os_view.eliom
@@ -94,7 +94,7 @@ let%shared disconnect_button ?a () =
        ]) ()
 
 let%shared sign_up_form ?a () =
-  generic_email_form ?a ~service:Os_services.sign_up_service' ()
+  generic_email_form ?a ~service:Os_services.sign_up_service ()
 
 let%shared forgot_password_form ?a () =
   generic_email_form ?a
@@ -103,7 +103,7 @@ let%shared forgot_password_form ?a () =
 let%shared information_form ?a
     ?(firstname="") ?(lastname="") ?(password1="") ?(password2="")
     () =
-  D.Form.post_form ?a ~service:Os_services.set_personal_data_service'
+  D.Form.post_form ?a ~service:Os_services.set_personal_data_service
     (fun ((fname, lname), (passwordn1, passwordn2)) ->
        let pass1 = D.Form.input
            ~a:[a_placeholder "Your password"]
@@ -147,7 +147,7 @@ let%shared information_form ?a
 
 
 let%shared preregister_form ?a label =
-  generic_email_form ?a ~service:Os_services.preregister_service' ~label ()
+  generic_email_form ?a ~service:Os_services.preregister_service ~label ()
 
 let%shared home_button ?a () =
   Form.get_form ?a ~service:Os_services.main_service

--- a/template.distillery/PROJECT_NAME.eliom
+++ b/template.distillery/PROJECT_NAME.eliom
@@ -4,23 +4,23 @@
 let%shared () =
   (* Registering services. Feel free to customize handlers. *)
   Eliom_registration.Action.register
-    ~service:Os_services.set_personal_data_service'
-    %%%MODULE_NAME%%%_handlers.set_personal_data_handler';
+    ~service:Os_services.set_personal_data_service
+    %%%MODULE_NAME%%%_handlers.set_personal_data_handler;
 
   Eliom_registration.Action.register
-    ~service:Os_services.set_password_service'
-    %%%MODULE_NAME%%%_handlers.set_password_handler';
+    ~service:Os_services.set_password_service
+    %%%MODULE_NAME%%%_handlers.set_password_handler;
 
   Eliom_registration.Action.register
     ~service:Os_services.forgot_password_service
     %%%MODULE_NAME%%%_handlers.forgot_password_handler;
 
   Eliom_registration.Action.register
-    ~service:Os_services.preregister_service'
-    %%%MODULE_NAME%%%_handlers.preregister_handler';
+    ~service:Os_services.preregister_service
+    %%%MODULE_NAME%%%_handlers.preregister_handler;
 
   Eliom_registration.Action.register
-    ~service:Os_services.sign_up_service'
+    ~service:Os_services.sign_up_service
     Os_handlers.sign_up_handler;
 
   Eliom_registration.Unit.register

--- a/template.distillery/PROJECT_NAME_content.eliom
+++ b/template.distillery/PROJECT_NAME_content.eliom
@@ -74,7 +74,7 @@ module Connection = struct
   )
 
   let sign_up_form () =
-    Os_view.generic_email_form ~service:Os_services.sign_up_service' ()
+    Os_view.generic_email_form ~service:Os_services.sign_up_service ()
 
   let forgot_password_form () =
     Os_view.generic_email_form ~service:Os_services.forgot_password_service ()
@@ -225,7 +225,7 @@ module Settings = struct
         [
           div ~a:[a_class ["os-welcome-box"]] [
             p [pcdata "Change your password:"];
-            Forms.password_form ~service:Os_services.set_password_service' ();
+            Forms.password_form ~service:Os_services.set_password_service ();
             br ();
             Os_userbox.upload_pic_link
               none

--- a/template.distillery/PROJECT_NAME_handlers.eliom
+++ b/template.distillery/PROJECT_NAME_handlers.eliom
@@ -18,14 +18,14 @@ let upload_user_avatar_handler myid () ((), (cropping, photo)) =
     Lwt_unix.unlink (Filename.concat avatar_dir old_avatar )
 
 (* Set personal data *)
-let%server set_personal_data_handler' =
-  Os_session.connected_fun Os_handlers.set_personal_data_handler'
+let%server set_personal_data_handler =
+  Os_session.connected_fun Os_handlers.set_personal_data_handler
 
-let%client set_personal_data_handler' =
+let%client set_personal_data_handler =
   let set_personal_data_rpc =
     ~%(Eliom_client.server_function
          [%derive.json : ((string * string) * (string * string))]
-       @@ set_personal_data_handler' ())
+       @@ set_personal_data_handler ())
   in
   fun () -> set_personal_data_rpc
 
@@ -52,23 +52,22 @@ let%client activation_handler =
   fun akey () -> activation_handler_rpc akey
 
 (* Set password *)
-let%server set_password_handler' =
-  Os_session.connected_fun Os_handlers.set_password_handler'
+let%server set_password_handler =
+  Os_session.connected_fun Os_handlers.set_password_handler
 
-let%client set_password_handler' () =
+let%client set_password_handler () =
   Os_handlers.set_password_rpc
 
 (* Preregister *)
-let%server preregister_handler' =
-  Os_handlers.preregister_handler'
+let%server preregister_handler =
+  Os_handlers.preregister_handler
 
-let%client preregister_handler' =
+let%client preregister_handler =
   let preregister_rpc =
     ~%(Eliom_client.server_function [%derive.json : string]
-       @@ preregister_handler' ())
+       @@ preregister_handler ())
   in
   fun () -> preregister_rpc
-
 
 let%shared main_service_handler userid_o () () = Eliom_content.Html.F.(
  %%%MODULE_NAME%%%_container.page userid_o (

--- a/template.distillery/PROJECT_NAME_handlers.eliomi
+++ b/template.distillery/PROJECT_NAME_handlers.eliomi
@@ -12,7 +12,7 @@ val upload_user_avatar_handler :
 
 [%%shared.start]
 
-val set_personal_data_handler' :
+val set_personal_data_handler :
   unit -> (string * string) * (string * string) -> unit Lwt.t
 
 val forgot_password_handler :
@@ -21,9 +21,9 @@ val forgot_password_handler :
 val activation_handler :
   string -> unit -> Eliom_registration.Action.result Lwt.t
 
-val set_password_handler' : unit -> string * string -> unit Lwt.t
+val set_password_handler : unit -> string * string -> unit Lwt.t
 
-val preregister_handler' : unit -> string -> unit Lwt.t
+val preregister_handler : unit -> string -> unit Lwt.t
 
 val main_service_handler :
   Os_user.id option ->


### PR DESCRIPTION
I suppose it was the previous convention naming (before the changes about services declarations).