### PR TITLE
HOTFIX in information_form: without Lwt.return, the validity state never changes.

### DIFF
--- a/src/os_view.eliom
+++ b/src/os_view.eliom
@@ -112,7 +112,8 @@ let%shared information_form ?a
              then
                (Js.Unsafe.coerce pass2)##(setCustomValidity
                ("Passwords do not match"))
-             else (Js.Unsafe.coerce pass2)##(setCustomValidity (""))
+             else (Js.Unsafe.coerce pass2)##(setCustomValidity (""));
+             Lwt.return ()
            )
          )
        ) : unit)]


### PR DESCRIPTION
If no `Lwt.return` the validity message remains.