### PR TITLE
WIP: Activation links now called Action links + make it possible to customize handler

### DIFF
--- a/src/os_data.eliom
+++ b/src/os_data.eliom
@@ -16,26 +16,19 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- *)
+*)
+
+(** Data types *)
+
 
 [%%shared.start]
 
-(** Call this function either from client or server side
-    to display an error message in the page.
-    The message is displayed in a special box created automatically
-    in the body of the page.
-    It is displayed during a short amount of time then disappears.
-    The two levels correspond to different classes that you can
-    personalize in CSS.
-
-    If [~onload] is [true], the message is displayed after the next page
-    is displayed (default [false]). When called on server side, this is
-    always the case.
-*)
-val msg :
-  ?level:[`Err | `Msg] -> ?duration:float -> ?onload:bool -> string -> unit
-
-[%%server.start]
-val action_link_key_created : bool Eliom_reference.Volatile.eref
-val wrong_pdata
-  : ((string * string) * (string * string)) option Eliom_reference.Volatile.eref
+(** Action links *)
+type actionlinkkey_info = {
+  userid : int64;
+  email : string;
+  validity : int64;
+  autoconnect : bool;
+  action : [ `AccountActivation | `PasswordReset | `Custom of string ];
+  data : string;
+}

--- a/src/os_db.ml
+++ b/src/os_db.ml
@@ -126,7 +126,7 @@ let emails_table =
        validated boolean NOT NULL DEFAULT(false)
           ) >>
 
-let activation_table :
+let action_link_table :
   (< .. >,
    < creationdate : < nul : Sql.non_nullable; .. > Sql.t > Sql.writable)
     Sql.view =
@@ -218,17 +218,7 @@ end
 
 module User = struct
 
-
-  type activationkey_info = {
-    userid : int64;
-    email : string;
-    validity : int64;
-    autoconnect : bool;
-    action : [ `AccountActivation | `PasswordReset | `Custom of string ];
-    data : string;
-  }
-
-  exception Invalid_activation_key of int64 (* userid *)
+  exception Invalid_action_link_key of int64 (* userid *)
 
   let userid_of_email email = one run_view
     ~success:(fun u -> Lwt.return u#!userid)
@@ -262,7 +252,7 @@ module User = struct
        e.email  = $string:email$
     >>
 
-  let add_activationkey ?(autoconnect=false)
+  let add_actionlinkkey ?(autoconnect=false)
       ?(action=`AccountActivation) ?(data="") ?(validity=1L)
       ~act_key ~userid ~email () =
     let action = match action with
@@ -270,7 +260,7 @@ module User = struct
       | `PasswordReset -> "passwordreset"
       | `Custom s -> s in
     run_query
-     <:insert< $activation_table$ :=
+     <:insert< $action_link_table$ :=
       { userid = $int64:userid$;
         email  = $string:email$;
         action = $string:action$;
@@ -278,7 +268,7 @@ module User = struct
         data   = $string:data$;
         validity = $int64:validity$;
         activationkey  = $string:act_key$;
-        creationdate   = activation_table?creationdate }
+        creationdate   = action_link_table?creationdate }
       >>
 
 
@@ -411,12 +401,12 @@ module User = struct
     ~fail:(Lwt.fail No_such_resource)
     <:view< t | t in $users_table$; t.userid = $int64:userid$ >>
 
-  let get_activationkey_info act_key =
+  let get_actionlinkkey_info act_key =
     full_transaction_block (fun dbh ->
       one (Lwt_Query.view dbh)
         ~fail:(Lwt.fail No_such_resource)
         <:view< t
-                | t in $activation_table$;
+                | t in $action_link_table$;
                 t.activationkey = $string:act_key$ >>
         ~success:(fun t ->
           let userid = t#!userid in
@@ -430,10 +420,11 @@ module User = struct
           let data = t#!data in
           let v  = max 0L (Int64.pred validity) in
           lwt () = Lwt_Query.query dbh
-              <:update< r in $activation_table$ := {validity = $int64:v$} |
+              <:update< r in $action_link_table$ := {validity = $int64:v$} |
                         r.activationkey = $string:act_key$ >>
           in
-          Lwt.return {userid; email; validity; action; data; autoconnect}
+          Lwt.return
+            {Os_data.userid; email; validity; action; data; autoconnect}
         )
     )
 

--- a/src/os_db.mli
+++ b/src/os_db.mli
@@ -41,16 +41,7 @@ module Email : sig
 end
 
 module User : sig
-  exception Invalid_activation_key of int64
-
-  type activationkey_info = {
-    userid : int64;
-    email : string;
-    validity : int64;
-    autoconnect : bool;
-    action : [ `AccountActivation | `Custom of string | `PasswordReset ];
-    data : string;
-  }
+  exception Invalid_action_link_key of int64
 
   val userid_of_email : string -> int64 Lwt.t
 
@@ -60,7 +51,7 @@ module User : sig
 
   val set_email_validated : int64 -> string -> unit Lwt.t
 
-  val add_activationkey :
+  val add_actionlinkkey :
     ?autoconnect:bool ->
     ?action:[< `AccountActivation | `Custom of string | `PasswordReset
              > `AccountActivation ] ->
@@ -97,7 +88,7 @@ module User : sig
   val user_of_userid :
     int64 -> (int64 * string * string * string option * bool) Lwt.t
 
-  val get_activationkey_info : string -> activationkey_info Lwt.t
+  val get_actionlinkkey_info : string -> Os_data.actionlinkkey_info Lwt.t
 
   val emails_of_userid : int64 -> string list Lwt.t
 

--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -242,7 +242,7 @@ let action_link_handler_common akey =
     then
       let%lwt () = Os_session.disconnect () in
       let%lwt () = Os_session.connect userid in
-      Lwt.return `Restart
+      Lwt.return `Restart_if_app
     else
       match action with
       | `Custom s ->
@@ -254,7 +254,7 @@ let action_link_handler_common akey =
   | Os_db.No_such_resource ->
     Eliom_reference.Volatile.set Os_userbox.action_link_key_outdated true;
     Os_msg.msg ~level:`Err ~onload:true
-      "Invalid action link key, please ask for a new one.";
+      "Invalid action key, please ask for a new one.";
     Lwt.return `NoReload
   | Os_db.Account_already_activated ->
     Eliom_reference.Volatile.set Os_userbox.action_link_key_outdated true;
@@ -268,6 +268,9 @@ let%client action_link_handler_common =
        [%derive.json: string]
        (Os_session.connected_wrapper action_link_handler_common))
 
+let%client restart_if_client_side = restart
+let%server restart_if_client_side () = ()
+
 let%shared action_link_handler _myid_o akey () =
   let%lwt a = action_link_handler_common akey in
   match a with
@@ -278,9 +281,9 @@ let%shared action_link_handler _myid_o akey () =
          (Redirection Eliom_service.reload_action))
   | `NoReload ->
     Eliom_registration.(appl_self_redirect Action.send) ()
-  | `Restart ->
-    ignore [%client (restart () : unit)];
-    Eliom_registration.(appl_self_redirect Unit.send) ()
+  | `Restart_if_app ->
+    restart_if_client_side ();
+    Eliom_registration.(appl_self_redirect Action.send) ()
   | `Custom_action_link (action_link, phantom_user) ->
     Lwt.fail (Custom_action_link (action_link, phantom_user))
 

--- a/src/os_handlers.eliomi
+++ b/src/os_handlers.eliomi
@@ -26,10 +26,30 @@ val disconnect_handler : unit -> unit -> unit Lwt.t
 
 val sign_up_handler : unit -> string -> unit Lwt.t
 
-val activation_handler :
-  string -> unit -> Eliom_registration.Action.result Lwt.t
-
 val add_email_handler : unit -> string -> unit Lwt.t
+
+exception Custom_action_link of
+    Os_data.actionlinkkey_info
+    * bool (* If true, the link corresponds to a phantom user
+              (user who never created its account).
+              In that case, you probably want to display a sign-up form,
+              and in the other case a login form. *)
+
+[%%server.start]
+
+val action_link_handler :
+  int64 option ->
+  string ->
+  unit ->
+  'a Eliom_registration.application_content Eliom_registration.kind Lwt.t
+
+[%%client.start]
+
+val action_link_handler :
+  int64 option ->
+  string ->
+  unit ->
+  Eliom_registration.browser_content Eliom_registration.kind Lwt.t
 
 [%%server.start]
 
@@ -50,3 +70,5 @@ val set_personal_data_handler' :
 [%%client.start]
 
 val set_password_rpc : string * string -> unit Lwt.t
+
+val restart : unit -> unit

--- a/src/os_msg.eliom
+++ b/src/os_msg.eliom
@@ -53,7 +53,7 @@ let%shared msg
       Lwt.return ())
     : unit)]
 
-let activation_key_created =
+let action_link_key_created =
   Eliom_reference.Volatile.eref ~scope:Eliom_common.request_scope false
 
 let wrong_pdata =

--- a/src/os_page.eliomi
+++ b/src/os_page.eliomi
@@ -103,6 +103,10 @@ module Make (C : PAGE) : sig
     [< Html_types.body_content ] Eliom_content.Html.elt list ->
     [> Html_types.html ] Eliom_content.Html.elt
 
+  (** Same but takes type [content]. *)
+  val make_page_full :
+    content -> [> Html_types.html ] Eliom_content.Html.elt
+
   (** Default wrapper for service handler generating pages.
       It takes as parameter a function generating page content
       (body content) and transforms it into a function generating

--- a/src/os_services.eliom
+++ b/src/os_services.eliom
@@ -89,11 +89,11 @@ let%server disconnect_service =
          (Eliom_parameter.unit, Eliom_parameter.unit))
     ()
 
-let%server activation_service =
+let%server action_link_service =
   Eliom_service.create
-    ~name:"activation"
+    ~name:"action_link"
     ~path:Eliom_service.No_path
-    ~meth:(Eliom_service.Get (Eliom_parameter.string "activationkey"))
+    ~meth:(Eliom_service.Get (Eliom_parameter.string "actionkey"))
     ()
 
 let%server set_password_service' =
@@ -121,6 +121,6 @@ let%client set_personal_data_service' = ~%set_personal_data_service'
 let%client sign_up_service' = ~%sign_up_service'
 let%client connect_service = ~%connect_service
 let%client disconnect_service = ~%disconnect_service
-let%client activation_service = ~%activation_service
+let%client action_link_service = ~%action_link_service
 let%client set_password_service' = ~%set_password_service'
 let%client add_email_service = ~%add_email_service

--- a/src/os_services.eliomi
+++ b/src/os_services.eliomi
@@ -128,7 +128,7 @@ val disconnect_service :
     Eliom_service.non_ocaml
   ) Eliom_service.t
 
-val activation_service :
+val action_link_service :
   (
     string,
     unit,

--- a/src/os_user.eliomi
+++ b/src/os_user.eliomi
@@ -28,17 +28,9 @@ exception No_such_user
 (** Has user set its password? *)
 val password_set : id -> bool Lwt.t
 
-type activationkey_info = {
-  userid : id;
-  email : string;
-  validity : int64;
-  autoconnect : bool;
-  action : [ `AccountActivation | `PasswordReset | `Custom of string ];
-  data : string;
-}
-
 [%%shared.start]
-  (** The type which represents a user. *)
+
+(** The type which represents a user. *)
 type t = {
     userid : id;
     fn : string;
@@ -67,8 +59,8 @@ val is_complete : t -> bool
 
 val emails_of_user : t -> string Lwt.t
 
-val add_activationkey :
-  (* by default, an activation key is just an activation key *)
+val add_actionlinkkey :
+  (* by default, an action_link key is just an activation key *)
   ?autoconnect:bool -> (** default: false *)
   ?action:[ `AccountActivation | `PasswordReset | `Custom of string ] ->
   (** default: `AccountActivation *)
@@ -82,12 +74,12 @@ val verify_password : email:string -> password:string -> id Lwt.t
     Results are cached in memory during page generation. *)
 val user_of_userid : id -> t Lwt.t
 
-val get_activationkey_info : string -> activationkey_info Lwt.t
-(** Retrieve the data corresponding to an activation key, each
+val get_actionlinkkey_info : string -> Os_data.actionlinkkey_info Lwt.t
+(** Retrieve the data corresponding to an action link key, each
     call decrements the validity of the key by 1 if it exists and
     validity > 0 (it remains at 0 if it's already 0). It is up to
     you to adapt the actions according to the value of validity!
-    Raises [Os_db.No_such_resource] if the activation key is not found. *)
+    Raises [Os_db.No_such_resource] if the action link key is not found. *)
 
 val userid_of_email : string -> id Lwt.t
 

--- a/src/os_userbox.eliom
+++ b/src/os_userbox.eliom
@@ -39,7 +39,7 @@ let user_does_not_exist =
 let user_already_preregistered =
   Eliom_reference.Volatile.eref ~scope:Eliom_common.request_scope false
 
-let activation_key_outdated =
+let action_link_key_outdated =
   Eliom_reference.Volatile.eref ~scope:Eliom_common.request_scope false
 
 let%shared upload_pic_link
@@ -208,7 +208,7 @@ let%client connection_box () =
   Lwt.return a
 
 let%server connection_box () =
-  if Eliom_reference.Volatile.get Os_msg.activation_key_created
+  if Eliom_reference.Volatile.get Os_msg.action_link_key_created
   then
     Lwt.return
       (D.div ~a:[a_id connection_box_id]
@@ -234,13 +234,13 @@ let%server connection_box () =
       let user_already_preregistered =
         Eliom_reference.Volatile.get user_already_preregistered
       in
-      let activation_key_outdated =
-        Eliom_reference.Volatile.get activation_key_outdated
+      let action_link_key_outdated =
+        Eliom_reference.Volatile.get action_link_key_outdated
       in
 
       if wrong_password
       then press o1
-      else if activation_key_outdated
+      else if action_link_key_outdated
       then press o2
       else if user_already_exists
       then press o34

--- a/src/os_userbox.eliomi
+++ b/src/os_userbox.eliomi
@@ -88,4 +88,4 @@ val set_user_menu :
   val user_already_exists : bool Eliom_reference.Volatile.eref
   val user_does_not_exist : bool Eliom_reference.Volatile.eref
   val user_already_preregistered : bool Eliom_reference.Volatile.eref
-  val activation_key_outdated : bool Eliom_reference.Volatile.eref
+  val action_link_key_outdated : bool Eliom_reference.Volatile.eref

--- a/src/os_view.eliom
+++ b/src/os_view.eliom
@@ -23,13 +23,14 @@
   open Eliom_content.Html.F
 ]
 
-let%shared generic_email_form ?a ?label ?(text="Send") ~service () =
+let%shared generic_email_form ?a ?label ?(text="Send") ?(email="") ~service () =
   D.Form.post_form ?a ~service
     (fun name ->
       let l = [
         Form.input
           ~a:[a_placeholder "e-mail address"]
           ~input_type:`Email
+          ~value:email
           ~name
           Form.string;
         Form.input
@@ -40,16 +41,17 @@ let%shared generic_email_form ?a ?label ?(text="Send") ~service () =
       ]
       in
       match label with
-        | None -> l
-        | Some lab -> F.label [pcdata lab]::l) ()
+      | None -> l
+      | Some lab -> F.label [pcdata lab]::l) ()
 
-let%shared connect_form ?a () =
+let%shared connect_form ?a ?(email = "") () =
   D.Form.post_form ?a ~xhr:false ~service:Os_services.connect_service
     (fun ((login, password), keepmeloggedin) -> [
       Form.input
         ~a:[a_placeholder "Your email"]
         ~name:login
         ~input_type:`Email
+        ~value:email
         Form.string;
       Form.input
         ~a:[a_placeholder "Your password"]
@@ -77,8 +79,8 @@ let%shared disconnect_button ?a () =
            [Ot_icons.F.signout (); pcdata "Logout"]
        ]) ()
 
-let%shared sign_up_form ?a () =
-  generic_email_form ?a ~service:Os_services.sign_up_service' ()
+let%shared sign_up_form ?a ?email () =
+  generic_email_form ?a ?email ~service:Os_services.sign_up_service' ()
 
 let%shared forgot_password_form ?a () =
   generic_email_form ?a

--- a/src/os_view.eliomi
+++ b/src/os_view.eliomi
@@ -25,6 +25,7 @@ val generic_email_form :
   ?a:[< Html_types.form_attrib ] Eliom_content.Html.D.attrib list ->
   ?label:string Eliom_content.Html.F.wrap ->
   ?text:string ->
+  ?email:string ->
   service:(
     unit,
     'a,
@@ -44,6 +45,7 @@ val generic_email_form :
 
 val connect_form :
   ?a:[< Html_types.form_attrib ] Eliom_content.Html.D.attrib list ->
+  ?email:string ->
   unit ->
   [> Html_types.form ] Eliom_content.Html.D.elt
 
@@ -54,6 +56,7 @@ val disconnect_button :
 
 val sign_up_form :
   ?a:[< Html_types.form_attrib ] Eliom_content.Html.D.attrib list ->
+  ?email:string ->
   unit ->
   [> Html_types.form ] Eliom_content.Html.D.elt
 

--- a/template.distillery/PROJECT_NAME.eliom
+++ b/template.distillery/PROJECT_NAME.eliom
@@ -32,8 +32,9 @@ let%shared () =
     Os_handlers.disconnect_handler;
 
   Eliom_registration.Any.register
-    ~service:Os_services.activation_service
-    %%%MODULE_NAME%%%_handlers.activation_handler;
+    ~service:Os_services.action_link_service
+    (Os_session.Opt.connected_fun
+       %%%MODULE_NAME%%%_handlers.action_link_handler);
 
   Eliom_registration.Action.register
     ~service:Os_services.add_email_service


### PR DESCRIPTION
Do not merge yet. The template is broken:
```
js_of_eliom -w +A-4-7-9-37-38-39-41-42-44-45-48 -ppx -c -package lwt.ppx -package js_of_ocaml.ppx -package js_of_ocaml.deriving.ppx -package ppx_deriving.std -package ocsigen-start.client -g bar_handlers.eliom
File "bar_handlers.eliom", line 80, characters 8-51:
Error: This expression has type Bar_base.App.result Lwt.t
       but an expression was expected of type
         Eliom_registration.browser_content Eliom_registration.kind Lwt.t
       Type
         Bar_base.App.result =
           Bar_base.App.app_id Eliom_registration.application_content
           Eliom_registration.kind
       is not compatible with type
         Eliom_registration.browser_content Eliom_registration.kind 
       Type Bar_base.App.app_id Eliom_registration.application_content
       is not compatible with type Eliom_registration.browser_content 
```