### PR TITLE
Os_types

### DIFF
--- a/src/os_current_user.eliom
+++ b/src/os_current_user.eliom
@@ -24,7 +24,7 @@ let section = Lwt_log.Section.make "os:current_user"
   type current_user =
     | CU_idontknown
     | CU_notconnected
-    | CU_user of Os_user.t
+    | CU_user of Os_types.user
 ]
 
 let%shared please_use_connected_fun =

--- a/src/os_current_user.eliomi
+++ b/src/os_current_user.eliomi
@@ -23,11 +23,11 @@
 type current_user =
   | CU_idontknown
   | CU_notconnected
-  | CU_user of Os_user.t
+  | CU_user of Os_types.user
 
-(** [get_current_user ()] returns the current user as a {!Os_user.t} type.
+(** [get_current_user ()] returns the current user as a {!Os_types.user} type.
     If no user is connected, it fails with {!Os_session.Not_connected}. *)
-val get_current_user : unit -> Os_user.t
+val get_current_user : unit -> Os_types.user
 
 (** [get_current_userid ()] returns the ID of the current user.
     If no user is connected, it fails with {!Os_session.Not_connected}. *)
@@ -35,9 +35,9 @@ val get_current_userid : unit -> Os_types.userid
 
 (** Instead of exception, the module [Opt] returns an option. *)
 module Opt : sig
-  (** [get_current_user ()] returns the current user as a [Os_user.t option]
+  (** [get_current_user ()] returns the current user as a [Os_types.user option]
       type. If no user is connected, [None] is returned. *)
-  val get_current_user : unit -> Os_user.t option
+  val get_current_user : unit -> Os_types.user option
 
   (** [get_current_userid ()] returns the ID of the current user as an option.
       If no user is connected, [None] is returned. *)

--- a/src/os_current_user.eliomi
+++ b/src/os_current_user.eliomi
@@ -31,7 +31,7 @@ val get_current_user : unit -> Os_user.t
 
 (** [get_current_userid ()] returns the ID of the current user.
     If no user is connected, it fails with {!Os_session.Not_connected}. *)
-val get_current_userid : unit -> Os_user.id
+val get_current_userid : unit -> Os_types.userid
 
 (** Instead of exception, the module [Opt] returns an option. *)
 module Opt : sig
@@ -41,7 +41,7 @@ module Opt : sig
 
   (** [get_current_userid ()] returns the ID of the current user as an option.
       If no user is connected, [None] is returned. *)
-  val get_current_userid : unit -> Os_user.id option
+  val get_current_userid : unit -> Os_types.userid option
 end
 
 [%%client.start]

--- a/src/os_db.ml
+++ b/src/os_db.ml
@@ -227,7 +227,7 @@ end
 
 module User = struct
 
-  exception Invalid_action_link_key of int64 (* userid *)
+  exception Invalid_action_link_key of Os_types.userid
 
   let userid_of_email email = one run_view
     ~success:(fun u -> Lwt.return u#!userid)
@@ -438,7 +438,7 @@ module User = struct
                         r.activationkey = $string:act_key$ >>
           in
           Lwt.return
-            {Os_data.userid; email; validity; action; data; autoconnect}
+            {Os_types.userid; email; validity; action; data; autoconnect}
         )
     )
 

--- a/src/os_group.ml
+++ b/src/os_group.ml
@@ -20,11 +20,9 @@
 
 exception No_such_group
 
-type id = int64
-
 (** The type of a group *)
 type t = {
-  id : id;
+  id : Os_types.groupid;
   name : string;
   desc : string option;
 }

--- a/src/os_group.ml
+++ b/src/os_group.ml
@@ -20,30 +20,24 @@
 
 exception No_such_group
 
-(** The type of a group *)
-type t = {
-  id : Os_types.groupid;
-  name : string;
-  desc : string option;
-}
-
-(** Create a group of type [t] using db informations. *)
-let create_group_from_db (groupid, name, description) = {
+(** Create a group of type [Os_types.group] using db informations. *)
+let create_group_from_db (groupid, name, description) : Os_types.group =
+  let open Os_types in {
   id = groupid;
   name = name;
   desc = description;
 }
 
-let id_of_group g = g.id
-let name_of_group g = g.name
-let desc_of_group g = g.desc
+let id_of_group (g : Os_types.group)    = Os_types.(g.id)
+let name_of_group (g : Os_types.group)  = Os_types.(g.name)
+let desc_of_group (g : Os_types.group)  = Os_types.(g.desc)
 
 (* Using cache tools to prevent multiple same database queries
    during the request. *)
 module MCache = Os_request_cache.Make(
 struct
   type key = string
-  type value = t
+  type value = Os_types.group
 
   let compare = compare
   let get key =
@@ -54,7 +48,7 @@ struct
 end)
 
 (** Helper function which creates a new group and return it as
-  * a record of type [t]. *)
+  * a record of type [Os_types.group]. *)
 let create ?description name =
   let group_of_name name =
     let%lwt g = Os_db.Groups.group_of_name name in
@@ -76,17 +70,19 @@ let group_of_name = MCache.get
 (* -----------------------------------------------------------------
  *
  * All the followings functions are only helpers/wrappers around db
- * functions ones. They generally use the type [t] of the module
- * and get rid of the part of picking each field of the record [t].
+ * functions ones. They generally use the type [Os_types.group] of the module
+ * and get rid of the part of picking each field of the record [Os_types.group].
  *
  * *)
 
-let add_user_in_group ~group =
-  Os_db.Groups.add_user_in_group ~groupid:(group.id)
-let remove_user_in_group ~group =
-  Os_db.Groups.remove_user_in_group ~groupid:(group.id)
-let in_group ~group =
-  Os_db.Groups.in_group ~groupid:(group.id)
+let add_user_in_group ~(group : Os_types.group) =
+  Os_db.Groups.add_user_in_group ~groupid:(Os_types.(group.id))
+
+let remove_user_in_group ~(group : Os_types.group) =
+  Os_db.Groups.remove_user_in_group ~groupid:(Os_types.(group.id))
+
+let in_group ~(group : Os_types.group) =
+  Os_db.Groups.in_group ~groupid:(Os_types.(group.id))
 
 (** Returns all the groups of the database. *)
 let all () =

--- a/src/os_group.ml
+++ b/src/os_group.ml
@@ -20,6 +20,14 @@
 
 exception No_such_group
 
+type id = Os_types.groupid [@@deriving json]
+
+type t = Os_types.group = {
+  id    : id;
+  name  : string;
+  desc  : string option;
+} [@@deriving json]
+
 (** Create a group of type [Os_types.group] using db informations. *)
 let create_group_from_db (groupid, name, description) : Os_types.group =
   let open Os_types in {

--- a/src/os_group.mli
+++ b/src/os_group.mli
@@ -32,25 +32,22 @@ exception No_such_group
 
 *)
 
-(** The type of a group *)
-type t
-
 (** [id_of_group group] returns the group ID. *)
-val id_of_group : t -> Os_types.groupid
+val id_of_group : Os_types.group -> Os_types.groupid
 
 (** [name_of_group group] returns the group name. *)
-val name_of_group : t -> string
+val name_of_group : Os_types.group -> string
 
 (** [desc_of_group group] returns the group description. *)
-val desc_of_group : t -> string option
+val desc_of_group : Os_types.group -> string option
 
 (** [create ~description name] creates a new group in the database and returns
-    it as a record of type [t]. *)
-val create : ?description:string -> string -> t Lwt.t
+    it as a record of type [Os_types.group]. *)
+val create : ?description:string -> string -> Os_types.group Lwt.t
 
 (** Overwrites the function [get_group] of [Os_db.User] and use
     the [get] function of the cache module. *)
-val group_of_name : string -> t Lwt.t
+val group_of_name : string -> Os_types.group Lwt.t
 
 (* -----------------------------------------------------------------
 
@@ -62,15 +59,24 @@ val group_of_name : string -> t Lwt.t
 
 (** [add_user_in_group ~group ~userid] adds the user with ID [userid] to
     [group]. *)
-val add_user_in_group : group:t -> userid:Os_types.userid -> unit Lwt.t
+val add_user_in_group :
+  group:Os_types.group ->
+  userid:Os_types.userid ->
+  unit Lwt.t
 
 (** [remove_user_in_group ~group ~userid] removes the user with ID [userid] from
     [group]. *)
-val remove_user_in_group : group:t -> userid:Os_types.userid -> unit Lwt.t
+val remove_user_in_group :
+  group:Os_types.group ->
+  userid:Os_types.userid ->
+  unit Lwt.t
 
 (** [in_group ~group ~userid] returns [true] if the user with ID [userid] is in
     [group]. *)
-val in_group : group:t -> userid:Os_types.userid -> bool Lwt.t
+val in_group :
+  group:Os_types.group ->
+  userid:Os_types.userid ->
+  bool Lwt.t
 
 (** [all ()] returns all the groups of the database. *)
-val all : unit -> t list Lwt.t
+val all : unit -> Os_types.group list Lwt.t

--- a/src/os_group.mli
+++ b/src/os_group.mli
@@ -32,6 +32,16 @@ exception No_such_group
 
 *)
 
+(** Type alias to {!Os_types.groupid} to allow to use [Os_group.id]. *)
+type id = Os_types.groupid [@@deriving json]
+
+(** Type alias to {!Os_types.group} to allow to use [Os_group.t]. *)
+type t = Os_types.group = {
+  id    : id;
+  name  : string;
+  desc  : string option;
+} [@@deriving json]
+
 (** [id_of_group group] returns the group ID. *)
 val id_of_group : Os_types.group -> Os_types.groupid
 

--- a/src/os_group.mli
+++ b/src/os_group.mli
@@ -32,13 +32,11 @@ exception No_such_group
 
 *)
 
-type id = int64
-
 (** The type of a group *)
 type t
 
 (** [id_of_group group] returns the group ID. *)
-val id_of_group : t -> id
+val id_of_group : t -> Os_types.groupid
 
 (** [name_of_group group] returns the group name. *)
 val name_of_group : t -> string
@@ -64,15 +62,15 @@ val group_of_name : string -> t Lwt.t
 
 (** [add_user_in_group ~group ~userid] adds the user with ID [userid] to
     [group]. *)
-val add_user_in_group : group:t -> userid:Os_user.id -> unit Lwt.t
+val add_user_in_group : group:t -> userid:Os_types.userid -> unit Lwt.t
 
 (** [remove_user_in_group ~group ~userid] removes the user with ID [userid] from
     [group]. *)
-val remove_user_in_group : group:t -> userid:Os_user.id -> unit Lwt.t
+val remove_user_in_group : group:t -> userid:Os_types.userid -> unit Lwt.t
 
 (** [in_group ~group ~userid] returns [true] if the user with ID [userid] is in
     [group]. *)
-val in_group : group:t -> userid:Os_user.id -> bool Lwt.t
+val in_group : group:t -> userid:Os_types.userid -> bool Lwt.t
 
 (** [all ()] returns all the groups of the database. *)
 val all : unit -> t list Lwt.t

--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -39,7 +39,7 @@ let%server set_personal_data_handler myid ()
      Lwt.return ())
   else (
     let%lwt user = Os_user.user_of_userid myid in
-    let open Os_user in
+    let open Os_types in
     let record = {
       user with
       fn = firstname;

--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -262,7 +262,7 @@ let%client connect_handler () v = connect_handler_rpc v
 
 [%%shared
   exception Custom_action_link of
-      Os_data.actionlinkkey_info
+      Os_types.actionlinkkey_info
       * bool (* If true, the link corresponds to a phantom user
                 (user who never created its account).
                 In that case, you probably want to display a sign-up form,
@@ -280,7 +280,7 @@ let action_link_handler_common akey =
   let myid_o = Os_current_user.Opt.get_current_userid () in
   try%lwt
     let%lwt
-      {Os_data.userid; email; validity; action; data = _; autoconnect}
+      {Os_types.userid; email; validity; action; data = _; autoconnect}
       as action_link =
       Os_user.get_actionlinkkey_info akey
     in

--- a/src/os_handlers.eliomi
+++ b/src/os_handlers.eliomi
@@ -35,7 +35,7 @@ val sign_up_handler : unit -> string -> unit Lwt.t
 val add_email_handler : unit -> string -> unit Lwt.t
 
 exception Custom_action_link of
-    Os_data.actionlinkkey_info
+    Os_types.actionlinkkey_info
     * bool (* If true, the link corresponds to a phantom user
               (user who never created its account).
               In that case, you probably want to display a sign-up form,
@@ -68,10 +68,11 @@ val forgot_password_handler :
 val preregister_handler :
   unit -> string -> unit Lwt.t
 
-val set_password_handler : Os_user.id -> unit -> string * string -> unit Lwt.t
+val set_password_handler :
+  Os_types.userid -> unit -> string * string -> unit Lwt.t
 
 val set_personal_data_handler :
-  Os_user.id -> unit -> (string * string) * (string * string) -> unit Lwt.t
+  Os_types.userid -> unit -> (string * string) * (string * string) -> unit Lwt.t
 
 [%%client.start]
 

--- a/src/os_notif.eliom
+++ b/src/os_notif.eliom
@@ -36,8 +36,12 @@ module type S = sig
   val listen : key -> unit
   val unlisten : key -> unit
   val unlisten_user :
-    ?sitedata:Eliom_common.sitedata -> userid:Os_user.id -> key -> unit
-  val notify : ?notfor:[`Me | `User of Os_user.id] -> key -> server_notif -> unit
+    ?sitedata:Eliom_common.sitedata -> userid:Os_types.userid -> key -> unit
+  val notify :
+    ?notfor:[`Me | `User of Os_types.userid] ->
+    key ->
+    server_notif ->
+    unit
   val client_ev : unit -> (key * client_notif) Eliom_react.Down.t
 end
 
@@ -48,9 +52,9 @@ module Make(A : sig
       val prepare : int64 option -> server_notif -> client_notif option Lwt.t
     end) = struct
 
-	type key = A.key
-	type server_notif = A.server_notif
-	type client_notif = A.client_notif
+  type key = A.key
+  type server_notif = A.server_notif
+  type client_notif = A.client_notif
 
   module Notif_hastbl =
     Hashtbl.Make(struct type t = A.key
@@ -61,7 +65,7 @@ module Make(A : sig
   module Weak_tbl =
     Weak.Make(struct
       type t =
-        (int64 option *
+        (Os_types.userid option *
          ((A.key * A.client_notif) Eliom_react.Down.t *
           (A.key * A.client_notif) React.event *
           (?step:React.step -> (A.key * A.client_notif) -> unit))) option
@@ -213,7 +217,7 @@ VVV See if it is still needed
 end
 
 module Simple(A : sig type key type notification end) = Make
-	(struct
+  (struct
     type key = A.key
     type server_notif = A.notification
     type client_notif = A.notification

--- a/src/os_notif.eliomi
+++ b/src/os_notif.eliomi
@@ -61,7 +61,7 @@ module type S = sig
 
   (** Make a user stop listening on data [key] *)
   val unlisten_user :
-    ?sitedata:Eliom_common.sitedata -> userid:Os_user.id -> key -> unit
+    ?sitedata:Eliom_common.sitedata -> userid:Os_types.userid -> key -> unit
 
   (** Call [notify id] to send a notification to all clients currently
       listening on data [key].
@@ -71,7 +71,11 @@ module type S = sig
       happen). If it is [`User id] it won't be sent to the user with id [id].
   *)
   (*TODO: is the restriction to the current tab relevant?*)
-  val notify : ?notfor:[`Me | `User of Os_user.id] -> key -> server_notif -> unit
+  val notify :
+    ?notfor:[`Me | `User of Os_types.userid] ->
+    key ->
+    server_notif ->
+    unit
 
   (** Returns the client react event. Map a function on this event to react
       to notifications from the server.
@@ -103,7 +107,7 @@ module Make (A : sig
       *)
       val prepare : int64 option -> server_notif -> client_notif option Lwt.t
     end) :
-	S with type key = A.key
+  S with type key = A.key
      and type server_notif = A.server_notif
      and type client_notif = A.client_notif
 
@@ -111,6 +115,6 @@ module Simple (A : sig
       type key
       type notification
     end) :
-	S with type key = A.key
+  S with type key = A.key
      and type server_notif = A.notification
      and type client_notif = A.notification

--- a/src/os_notif.eliomi
+++ b/src/os_notif.eliomi
@@ -107,7 +107,7 @@ module Make (A : sig
       *)
       val prepare : int64 option -> server_notif -> client_notif option Lwt.t
     end) :
-  S with type key = A.key
+       S with type key = A.key
      and type server_notif = A.server_notif
      and type client_notif = A.client_notif
 
@@ -115,6 +115,6 @@ module Simple (A : sig
       type key
       type notification
     end) :
-  S with type key = A.key
+       S with type key = A.key
      and type server_notif = A.notification
      and type client_notif = A.notification

--- a/src/os_page.eliom
+++ b/src/os_page.eliom
@@ -56,12 +56,12 @@
       Html_types.body_content Eliom_content.Html.elt list Lwt.t
     val default_error_page_full : ('a -> 'b -> exn -> content Lwt.t) option
     val default_connected_error_page :
-      Os_user.id option -> 'a -> 'b -> exn ->
+      Os_types.userid option -> 'a -> 'b -> exn ->
       Html_types.body_content Eliom_content.Html.elt list Lwt.t
     val default_connected_error_page_full :
-      (Os_user.id option -> 'a -> 'b -> exn -> content Lwt.t) option
+      (Os_types.userid option -> 'a -> 'b -> exn -> content Lwt.t) option
     val default_predicate : 'a -> 'b -> bool Lwt.t
-    val default_connected_predicate : Os_user.id option -> 'a -> 'b -> bool Lwt.t
+    val default_connected_predicate : Os_types.userid option -> 'a -> 'b -> bool Lwt.t
   end
 
   module Default_config = struct
@@ -243,7 +243,7 @@
           ?(predicate = C.default_connected_predicate)
           ?(fallback = default_connected_error_page)
           f gp pp =
-        let f_wrapped (uid_o : Os_user.id option) gp pp =
+        let f_wrapped (uid_o : Os_types.userid option) gp pp =
           try%lwt
             let%lwt b = predicate uid_o gp pp in
             if b then

--- a/src/os_page.eliomi
+++ b/src/os_page.eliomi
@@ -132,8 +132,8 @@ module Make (C : PAGE) : sig
       See {!Eliom_session.Opt.connected_fun}.
   *)
     val connected_page :
-      ?allow:Os_group.t list ->
-      ?deny:Os_group.t list ->
+      ?allow:Os_types.group list ->
+      ?deny:Os_types.group list ->
       ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
       ?fallback:(Os_types.userid option -> 'a -> 'b -> exn ->
                  Html_types.body_content Eliom_content.Html.elt
@@ -146,8 +146,8 @@ module Make (C : PAGE) : sig
         first checks if the user is connected.
     *)
     val connected_page_full :
-      ?allow:Os_group.t list ->
-      ?deny:Os_group.t list ->
+      ?allow:Os_types.group list ->
+      ?deny:Os_types.group list ->
       ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
       ?fallback:(Os_types.userid option -> 'a -> 'b -> exn -> content Lwt.t) ->
       (Os_types.userid option -> 'a -> 'b -> content Lwt.t) ->
@@ -158,8 +158,8 @@ module Make (C : PAGE) : sig
       See {!Eliom_session.connected_fun}.
   *)
   val connected_page :
-       ?allow:Os_group.t list
-    -> ?deny:Os_group.t list
+       ?allow:Os_types.group list
+    -> ?deny:Os_types.group list
     -> ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t)
     -> ?fallback:(Os_types.userid option -> 'a -> 'b -> exn ->
                   Html_types.body_content Eliom_content.Html.elt list
@@ -174,8 +174,8 @@ module Make (C : PAGE) : sig
       first checks if user is connected.
   *)
   val connected_page_full :
-    ?allow:Os_group.t list ->
-    ?deny:Os_group.t list ->
+    ?allow:Os_types.group list ->
+    ?deny:Os_types.group list ->
     ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
     ?fallback:(Os_types.userid option -> 'a -> 'b -> exn -> content Lwt.t) ->
     (Os_types.userid -> 'a -> 'b -> content Lwt.t) ->

--- a/src/os_page.eliomi
+++ b/src/os_page.eliomi
@@ -77,19 +77,19 @@ module type PAGE = sig
 
   (** Default error page for connected pages. *)
   val default_connected_error_page :
-    Os_user.id option -> 'a -> 'b -> exn ->
+    Os_types.userid option -> 'a -> 'b -> exn ->
     Html_types.body_content Eliom_content.Html.elt list Lwt.t
 
   (** Default error page for connected pages (with custom headers and
       title). *)
   val default_connected_error_page_full :
-    (Os_user.id option -> 'a -> 'b -> exn -> content Lwt.t) option
+    (Os_types.userid option -> 'a -> 'b -> exn -> content Lwt.t) option
 
   (** Default predicate. *)
   val default_predicate : 'a -> 'b -> bool Lwt.t
 
   (** Default predicate for connected pages. *)
-  val default_connected_predicate : Os_user.id option -> 'a -> 'b -> bool Lwt.t
+  val default_connected_predicate : Os_types.userid option -> 'a -> 'b -> bool Lwt.t
 
 end
 
@@ -134,11 +134,11 @@ module Make (C : PAGE) : sig
     val connected_page :
       ?allow:Os_group.t list ->
       ?deny:Os_group.t list ->
-      ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
-      ?fallback:(Os_user.id option -> 'a -> 'b -> exn ->
+      ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
+      ?fallback:(Os_types.userid option -> 'a -> 'b -> exn ->
                  Html_types.body_content Eliom_content.Html.elt
                    list Lwt.t) ->
-      (Os_user.id option -> 'a -> 'b ->
+      (Os_types.userid option -> 'a -> 'b ->
        Html_types.body_content Eliom_content.Html.elt list Lwt.t) ->
       ('a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t)
 
@@ -148,9 +148,9 @@ module Make (C : PAGE) : sig
     val connected_page_full :
       ?allow:Os_group.t list ->
       ?deny:Os_group.t list ->
-      ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
-      ?fallback:(Os_user.id option -> 'a -> 'b -> exn -> content Lwt.t) ->
-      (Os_user.id option -> 'a -> 'b -> content Lwt.t) ->
+      ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
+      ?fallback:(Os_types.userid option -> 'a -> 'b -> exn -> content Lwt.t) ->
+      (Os_types.userid option -> 'a -> 'b -> content Lwt.t) ->
       ('a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t)
   end
 
@@ -160,11 +160,11 @@ module Make (C : PAGE) : sig
   val connected_page :
        ?allow:Os_group.t list
     -> ?deny:Os_group.t list
-    -> ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t)
-    -> ?fallback:(Os_user.id option -> 'a -> 'b -> exn ->
+    -> ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t)
+    -> ?fallback:(Os_types.userid option -> 'a -> 'b -> exn ->
                   Html_types.body_content Eliom_content.Html.elt list
                     Lwt.t)
-    -> (Os_user.id -> 'a -> 'b ->
+    -> (Os_types.userid -> 'a -> 'b ->
         Html_types.body_content Eliom_content.Html.elt list Lwt.t)
     -> 'a -> 'b
     -> Html_types.html Eliom_content.Html.elt Lwt.t
@@ -176,8 +176,8 @@ module Make (C : PAGE) : sig
   val connected_page_full :
     ?allow:Os_group.t list ->
     ?deny:Os_group.t list ->
-    ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
-    ?fallback:(Os_user.id option -> 'a -> 'b -> exn -> content Lwt.t) ->
-    (Os_user.id -> 'a -> 'b -> content Lwt.t) ->
+    ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
+    ?fallback:(Os_types.userid option -> 'a -> 'b -> exn -> content Lwt.t) ->
+    (Os_types.userid -> 'a -> 'b -> content Lwt.t) ->
     ('a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t)
 end

--- a/src/os_session.eliomi
+++ b/src/os_session.eliomi
@@ -28,15 +28,15 @@ val on_start_process : (unit -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done
     when the process starts in connected mode, or when the user logs in *)
-val on_start_connected_process : (Os_user.id -> unit Lwt.t) -> unit
+val on_start_connected_process : (Os_types.userid -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done at each connected request.
     The function takes the user id as parameter. *)
-val on_connected_request : (Os_user.id -> unit Lwt.t) -> unit
+val on_connected_request : (Os_types.userid -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done just after opening a session
     The function takes the user id as parameter. *)
-val on_open_session : (Os_user.id -> unit Lwt.t) -> unit
+val on_open_session : (Os_types.userid -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done just before closing the session *)
 val on_pre_close_session : (unit -> unit Lwt.t) -> unit
@@ -49,7 +49,7 @@ val on_request : (unit -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done just for each denied request.
     The function takes the user id as parameter, if some user is connected. *)
-val on_denied_request : (Os_user.id option -> unit Lwt.t) -> unit
+val on_denied_request : (Os_types.userid option -> unit Lwt.t) -> unit
 
 
 (** Scopes that are independant from user connection.
@@ -74,7 +74,7 @@ exception Permission_denied
     argument [expire] to true, the session will expire when the browser
     exits.
 *)
-val connect : ?expire:bool -> Os_user.id -> unit Lwt.t
+val connect : ?expire:bool -> Os_types.userid -> unit Lwt.t
 
 (** Close a session by discarding server side states for current browser
     (session and session group), current client process (tab) and current
@@ -104,48 +104,48 @@ val disconnect : unit -> unit Lwt.t
 val connected_fun :
   ?allow:Os_group.t list ->
   ?deny:Os_group.t list ->
-  ?deny_fun:(Os_user.id option -> 'c Lwt.t) ->
-  (Os_user.id -> 'a -> 'b -> 'c Lwt.t) ->
+  ?deny_fun:(Os_types.userid option -> 'c Lwt.t) ->
+  (Os_types.userid -> 'a -> 'b -> 'c Lwt.t) ->
   ('a -> 'b -> 'c Lwt.t)
 
 (** Wrapper for server functions (see {!connected_fun}). *)
 val connected_rpc :
   ?allow:Os_group.t list ->
   ?deny:Os_group.t list ->
-  ?deny_fun:(Os_user.id option -> 'b Lwt.t) ->
-  (Os_user.id -> 'a -> 'b Lwt.t) ->
+  ?deny_fun:(Os_types.userid option -> 'b Lwt.t) ->
+  (Os_types.userid -> 'a -> 'b Lwt.t) ->
   ('a -> 'b Lwt.t)
 
 (** Wrapper for server functions when you do not need userid. *)
 val connected_wrapper :
   ?allow:Os_group.t list ->
   ?deny:Os_group.t list ->
-  ?deny_fun:(Os_user.id option -> 'b Lwt.t) ->
+  ?deny_fun:(Os_types.userid option -> 'b Lwt.t) ->
   ('a -> 'b Lwt.t) ->
   ('a -> 'b Lwt.t)
 
 module Opt : sig
 
   (** Same as {!connected_fun} but instead of failing in case the user is
-      not connected, the function given as parameter takes an [Os_user.id
+      not connected, the function given as parameter takes an [Os_types.userid
       option] for user id.
   *)
   val connected_fun :
     ?allow:Os_group.t list ->
     ?deny:Os_group.t list ->
-    ?deny_fun:(Os_user.id option -> 'c Lwt.t) ->
-    (Os_user.id option -> 'a -> 'b -> 'c Lwt.t) ->
+    ?deny_fun:(Os_types.userid option -> 'c Lwt.t) ->
+    (Os_types.userid option -> 'a -> 'b -> 'c Lwt.t) ->
     ('a -> 'b -> 'c Lwt.t)
 
   (** Same as {!connected_rpc} but instead of failing in case the user is
-      not connected, the function given as parameter takes an [Os_user.id
+      not connected, the function given as parameter takes an [Os_types.userid
       option] for user id.
   *)
   val connected_rpc :
     ?allow:Os_group.t list ->
     ?deny:Os_group.t list ->
-    ?deny_fun:(Os_user.id option -> 'b Lwt.t) ->
-    (Os_user.id option -> 'a -> 'b Lwt.t) ->
+    ?deny_fun:(Os_types.userid option -> 'b Lwt.t) ->
+    (Os_types.userid option -> 'a -> 'b Lwt.t) ->
     ('a -> 'b Lwt.t)
 
 end
@@ -154,4 +154,4 @@ end
 (**/**)
 [%%client.start]
    (** internal. Do not use *)
-val get_current_userid_o : (unit -> Os_user.id option) ref
+val get_current_userid_o : (unit -> Os_types.userid option) ref

--- a/src/os_session.eliomi
+++ b/src/os_session.eliomi
@@ -102,24 +102,24 @@ val disconnect : unit -> unit Lwt.t
     When called on client side, no security check is done.
 *)
 val connected_fun :
-  ?allow:Os_group.t list ->
-  ?deny:Os_group.t list ->
+  ?allow:Os_types.group list ->
+  ?deny:Os_types.group list ->
   ?deny_fun:(Os_types.userid option -> 'c Lwt.t) ->
   (Os_types.userid -> 'a -> 'b -> 'c Lwt.t) ->
   ('a -> 'b -> 'c Lwt.t)
 
 (** Wrapper for server functions (see {!connected_fun}). *)
 val connected_rpc :
-  ?allow:Os_group.t list ->
-  ?deny:Os_group.t list ->
+  ?allow:Os_types.group list ->
+  ?deny:Os_types.group list ->
   ?deny_fun:(Os_types.userid option -> 'b Lwt.t) ->
   (Os_types.userid -> 'a -> 'b Lwt.t) ->
   ('a -> 'b Lwt.t)
 
 (** Wrapper for server functions when you do not need userid. *)
 val connected_wrapper :
-  ?allow:Os_group.t list ->
-  ?deny:Os_group.t list ->
+  ?allow:Os_types.group list ->
+  ?deny:Os_types.group list ->
   ?deny_fun:(Os_types.userid option -> 'b Lwt.t) ->
   ('a -> 'b Lwt.t) ->
   ('a -> 'b Lwt.t)
@@ -131,8 +131,8 @@ module Opt : sig
       option] for user id.
   *)
   val connected_fun :
-    ?allow:Os_group.t list ->
-    ?deny:Os_group.t list ->
+    ?allow:Os_types.group list ->
+    ?deny:Os_types.group list ->
     ?deny_fun:(Os_types.userid option -> 'c Lwt.t) ->
     (Os_types.userid option -> 'a -> 'b -> 'c Lwt.t) ->
     ('a -> 'b -> 'c Lwt.t)
@@ -142,8 +142,8 @@ module Opt : sig
       option] for user id.
   *)
   val connected_rpc :
-    ?allow:Os_group.t list ->
-    ?deny:Os_group.t list ->
+    ?allow:Os_types.group list ->
+    ?deny:Os_types.group list ->
     ?deny_fun:(Os_types.userid option -> 'b Lwt.t) ->
     (Os_types.userid option -> 'a -> 'b Lwt.t) ->
     ('a -> 'b Lwt.t)

--- a/src/os_types.eliom
+++ b/src/os_types.eliom
@@ -25,14 +25,27 @@
 
 type userid = int64 [@@deriving json]
 
+type user = {
+    userid : userid;
+    fn : string;
+    ln : string;
+    avatar : string option;
+  } [@@deriving json]
+
 (** Action links *)
 type actionlinkkey_info = {
-  userid : userid;
-  email : string;
-  validity : int64;
-  autoconnect : bool;
-  action : [ `AccountActivation | `PasswordReset | `Custom of string ];
-  data : string;
+  userid        : userid;
+  email         : string;
+  validity      : int64;
+  autoconnect   : bool;
+  action        : [ `AccountActivation | `PasswordReset | `Custom of string ];
+  data          : string;
 }
 
 type groupid = int64 [@@deriving json]
+
+type group = {
+  id    : groupid;
+  name  : string;
+  desc  : string option;
+}

--- a/src/os_types.eliom
+++ b/src/os_types.eliom
@@ -23,12 +23,16 @@
 
 [%%shared.start]
 
+type userid = int64 [@@deriving json]
+
 (** Action links *)
 type actionlinkkey_info = {
-  userid : int64;
+  userid : userid;
   email : string;
   validity : int64;
   autoconnect : bool;
   action : [ `AccountActivation | `PasswordReset | `Custom of string ];
   data : string;
 }
+
+type groupid = int64 [@@deriving json]

--- a/src/os_types.eliom
+++ b/src/os_types.eliom
@@ -18,13 +18,21 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 *)
 
-(** Data types *)
+(** Data types
+
+    This module defines types used in ocsigen-start in multiple files. It
+    gives a more readable interface (for example by using [Os_types.userid]
+    instead of [int64]). Put all most used types in this file avoids to have
+    dependencies between different modules for only one type.
+ **)
 
 
 [%%shared.start]
 
+(** Type representing a user ID *)
 type userid = int64 [@@deriving json]
 
+(** Type representing a user. See <<a_api | module Os_user >>. *)
 type user = {
     userid : userid;
     fn : string;
@@ -42,8 +50,10 @@ type actionlinkkey_info = {
   data          : string;
 }
 
+(** Type representing a group ID *)
 type groupid = int64 [@@deriving json]
 
+(** Type representing a group. See <<a_api | module Os_group >> *)
 type group = {
   id    : groupid;
   name  : string;

--- a/src/os_user.eliom
+++ b/src/os_user.eliom
@@ -20,19 +20,15 @@
 
 open Eliom_content.Html.F
 
-[%%shared
-  type id = int64 [@@deriving json]
-]
-
 [%%server
-  exception Already_exists of id
+  exception Already_exists of Os_types.userid
   exception No_such_user
 ]
 
 [%%shared
   (** The type which represents a user. *)
   type t = {
-    userid : id;
+    userid : Os_types.userid;
     fn : string;
     ln : string;
     avatar : string option;
@@ -81,7 +77,7 @@ include Os_db.User
    during the request. *)
 module MCache = Os_request_cache.Make(
 struct
-  type key = id
+  type key = Os_types.userid
   type value = t * bool
 
   let compare = compare

--- a/src/os_user.eliom
+++ b/src/os_user.eliom
@@ -20,6 +20,17 @@
 
 open Eliom_content.Html.F
 
+[%%shared
+  type id = Os_types.userid [@@deriving json]
+
+  type t = Os_types.user = {
+      userid : id;
+      fn : string;
+      ln : string;
+      avatar : string option;
+    } [@@deriving json]
+]
+
 [%%server
   exception Already_exists of Os_types.userid
   exception No_such_user

--- a/src/os_user.eliomi
+++ b/src/os_user.eliomi
@@ -28,33 +28,26 @@ val password_set : Os_types.userid -> bool Lwt.t
 [%%shared.start]
 
 (** The type which represents a user. *)
-type t = {
-    userid : Os_types.userid;
-    fn : string;
-    ln : string;
-    avatar : string option;
-  } [@@deriving json]
 
-
-val userid_of_user : t -> Os_types.userid
-val firstname_of_user : t -> string
-val lastname_of_user : t -> string
-val avatar_of_user : t -> string option
+val userid_of_user : Os_types.user -> Os_types.userid
+val firstname_of_user : Os_types.user -> string
+val lastname_of_user : Os_types.user -> string
+val avatar_of_user : Os_types.user -> string option
 val avatar_uri_of_avatar :
   ?absolute_path:bool -> string -> Eliom_content.Xml.uri
 val avatar_uri_of_user :
-  ?absolute_path:bool -> t -> Eliom_content.Xml.uri option
+  ?absolute_path:bool -> Os_types.user -> Eliom_content.Xml.uri option
 
 (** Retrieve the full name of user. *)
-val fullname_of_user : t -> string
+val fullname_of_user : Os_types.user -> string
 
-(** Returns true if the firstname and the lastname of [t] has not
+(** Returns true if the firstname and the lastname of [Os_types.user] has not
   * been completed yet. *)
-val is_complete : t -> bool
+val is_complete : Os_types.user -> bool
 
 [%%server.start]
 
-val emails_of_user : t -> string Lwt.t
+val emails_of_user : Os_types.user -> string Lwt.t
 
 val add_actionlinkkey :
   (* by default, an action_link key is just an activation key *)
@@ -69,7 +62,7 @@ val verify_password : email:string -> password:string -> Os_types.userid Lwt.t
 
 (** returns user information.
     Results are cached in memory during page generation. *)
-val user_of_userid : Os_types.userid -> t Lwt.t
+val user_of_userid : Os_types.userid -> Os_types.user Lwt.t
 
 val get_actionlinkkey_info : string -> Os_types.actionlinkkey_info Lwt.t
 (** Retrieve the data corresponding to an action link key, each
@@ -84,29 +77,30 @@ val userid_of_email : string -> Os_types.userid Lwt.t
 val emails_of_userid : Os_types.userid -> string list Lwt.t
 
 (** Retrieve the main e-mail of a user. *)
-val email_of_user : t -> string Lwt.t
+val email_of_user : Os_types.user -> string Lwt.t
 
 (** Retrieve the main e-mail from user id. *)
 val email_of_userid : Os_types.userid -> string Lwt.t
 
 (** Retrieve e-mails of a user. *)
-val emails_of_user : t -> string list Lwt.t
+val emails_of_user : Os_types.user -> string list Lwt.t
 
 (** Get users who match the [pattern] (useful for completion) *)
-val get_users : ?pattern:string -> unit -> t list Lwt.t
+val get_users : ?pattern:string -> unit -> Os_types.user list Lwt.t
 
 (** Create a new user *)
 val create :
   ?password:string -> ?avatar:string ->
-  firstname:string -> lastname:string -> string -> t Lwt.t
+  firstname:string -> lastname:string -> string -> Os_types.user Lwt.t
 
 (** Update the informations of a user. *)
 val update :
   ?password:string -> ?avatar:string ->
   firstname:string -> lastname:string -> Os_types.userid -> unit Lwt.t
 
-(** Another version of [update] using a type [t] instead of labels. *)
-val update' : ?password:string -> t -> unit Lwt.t
+(** Another version of [update] using a type [Os_types.user] instead of
+    label. *)
+val update' : ?password:string -> Os_types.user -> unit Lwt.t
 
 (** Update the password only *)
 val update_password : string -> Os_types.userid -> unit Lwt.t

--- a/src/os_user.eliomi
+++ b/src/os_user.eliomi
@@ -18,6 +18,19 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+[%%shared.start]
+
+(** Type alias to {!Os_types.userid} to allow to use [Os_user.id]. *)
+type id = Os_types.userid [@@deriving json]
+
+(** Type alias to {!Os_types.user} to allow to use [Os_user.t]. *)
+type t = Os_types.user = {
+    userid : id;
+    fn : string;
+    ln : string;
+    avatar : string option;
+  } [@@deriving json]
+
 [%%server.start]
 exception Already_exists of Os_types.userid
 exception No_such_user

--- a/src/os_user.eliomi
+++ b/src/os_user.eliomi
@@ -18,28 +18,25 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-[%%shared.start]
-type id = int64 [@@deriving json]
-
 [%%server.start]
-exception Already_exists of id
+exception Already_exists of Os_types.userid
 exception No_such_user
 
 (** Has user set its password? *)
-val password_set : id -> bool Lwt.t
+val password_set : Os_types.userid -> bool Lwt.t
 
 [%%shared.start]
 
 (** The type which represents a user. *)
 type t = {
-    userid : id;
+    userid : Os_types.userid;
     fn : string;
     ln : string;
     avatar : string option;
   } [@@deriving json]
 
 
-val userid_of_user : t -> id
+val userid_of_user : t -> Os_types.userid
 val firstname_of_user : t -> string
 val lastname_of_user : t -> string
 val avatar_of_user : t -> string option
@@ -66,31 +63,31 @@ val add_actionlinkkey :
   (** default: `AccountActivation *)
   ?data:string -> (** default: empty string *)
   ?validity:int64 -> (** default: 1L *)
-  act_key:string -> userid:id -> email:string -> unit -> unit Lwt.t
+  act_key:string -> userid:Os_types.userid -> email:string -> unit -> unit Lwt.t
 
-val verify_password : email:string -> password:string -> id Lwt.t
+val verify_password : email:string -> password:string -> Os_types.userid Lwt.t
 
 (** returns user information.
     Results are cached in memory during page generation. *)
-val user_of_userid : id -> t Lwt.t
+val user_of_userid : Os_types.userid -> t Lwt.t
 
-val get_actionlinkkey_info : string -> Os_data.actionlinkkey_info Lwt.t
+val get_actionlinkkey_info : string -> Os_types.actionlinkkey_info Lwt.t
 (** Retrieve the data corresponding to an action link key, each
     call decrements the validity of the key by 1 if it exists and
     validity > 0 (it remains at 0 if it's already 0). It is up to
     you to adapt the actions according to the value of validity!
     Raises [Os_db.No_such_resource] if the action link key is not found. *)
 
-val userid_of_email : string -> id Lwt.t
+val userid_of_email : string -> Os_types.userid Lwt.t
 
 (** Retrieve e-mails from user id. *)
-val emails_of_userid : id -> string list Lwt.t
+val emails_of_userid : Os_types.userid -> string list Lwt.t
 
 (** Retrieve the main e-mail of a user. *)
 val email_of_user : t -> string Lwt.t
 
 (** Retrieve the main e-mail from user id. *)
-val email_of_userid : id -> string Lwt.t
+val email_of_userid : Os_types.userid -> string Lwt.t
 
 (** Retrieve e-mails of a user. *)
 val emails_of_user : t -> string list Lwt.t
@@ -106,16 +103,16 @@ val create :
 (** Update the informations of a user. *)
 val update :
   ?password:string -> ?avatar:string ->
-  firstname:string -> lastname:string -> id -> unit Lwt.t
+  firstname:string -> lastname:string -> Os_types.userid -> unit Lwt.t
 
 (** Another version of [update] using a type [t] instead of labels. *)
 val update' : ?password:string -> t -> unit Lwt.t
 
 (** Update the password only *)
-val update_password : string -> id -> unit Lwt.t
+val update_password : string -> Os_types.userid -> unit Lwt.t
 
 (** Update the avatar only *)
-val update_avatar : string -> id -> unit Lwt.t
+val update_avatar : string -> Os_types.userid -> unit Lwt.t
 
 (** Check wether or not a user exists *)
 val is_registered : string -> bool Lwt.t
@@ -141,21 +138,21 @@ val all : ?limit:int64 -> unit -> string list Lwt.t
     by user, and as third parameter the hash found in database.
 *)
 val set_pwd_crypt_fun : (string -> string) *
-                        (id -> string -> string -> bool) -> unit
+                        (Os_types.userid -> string -> string -> bool) -> unit
 
 (** Removes the email [email] from the user with the id [userid],
     if the email is registered as the main email for the user it fails
     with the exception [Main_email_removal_attempt].
 *)
-val remove_email_from_user : userid:id -> email:string -> unit Lwt.t
+val remove_email_from_user : userid:Os_types.userid -> email:string -> unit Lwt.t
 
 (** Returns whether for a user designated by its id the given email has been
     validated. *)
-val is_email_validated : userid:id -> email:string -> bool Lwt.t
+val is_email_validated : userid:Os_types.userid -> email:string -> bool Lwt.t
 
 (** Returns whether an email is the  main email registered for a
     given user designated by its id. *)
-val is_main_email : userid:id -> email:string -> bool Lwt.t
+val is_main_email : userid:Os_types.userid -> email:string -> bool Lwt.t
 
 (** Sets the main email for a user with the id [userid] as the email [email]. *)
-val update_main_email : userid:id -> email:string -> unit Lwt.t
+val update_main_email : userid:Os_types.userid -> email:string -> unit Lwt.t

--- a/src/os_user_proxy.eliom
+++ b/src/os_user_proxy.eliom
@@ -19,13 +19,9 @@
  *)
 
 (*VVV Warning: Os already implements a cache of user, but for
-  Os_user.t only. It's ok. *)
+  Os_types.user only. It's ok. *)
 
-[%%shared
-  type userid = int64 [@@deriving json]
-]
-
-let%server cache : (userid, Os_user.t) Eliom_cscache.t =
+let%server cache : (Os_types.userid, Os_types.user) Eliom_cscache.t =
   Eliom_cscache.create ()
 
 
@@ -45,9 +41,9 @@ let%server get_data_rpc' =
 let%client get_data_rpc' = ()
 
 let%shared get_data_rpc
-  : (_, Os_user.t) Eliom_client.server_function =
+  : (_, Os_types.user) Eliom_client.server_function =
   Eliom_client.server_function ~name:"os_user_proxy.get_data_rpc"
-    [%derive.json: userid] get_data_rpc'
+    [%derive.json: Os_types.userid] get_data_rpc'
 
 let%client get_data id  = get_data_rpc id
 

--- a/src/os_user_proxy.eliomi
+++ b/src/os_user_proxy.eliomi
@@ -27,19 +27,19 @@ type userid = int64 [@@deriving json]
 
 val cache : (userid, Os_user.t) Eliom_cscache.t
 
-val get_data_from_db : 'a -> Os_user.id -> Os_user.t Lwt.t
+val get_data_from_db : 'a -> Os_types.userid -> Os_user.t Lwt.t
 
-val get_data : Os_user.id -> Os_user.t Lwt.t
+val get_data : Os_types.userid -> Os_user.t Lwt.t
 
-val get_data_from_db_for_client : 'a -> Os_user.id -> Os_user.t Lwt.t
+val get_data_from_db_for_client : 'a -> Os_types.userid -> Os_user.t Lwt.t
 
-val get_data_rpc' : Os_user.id -> Os_user.t Lwt.t
+val get_data_rpc' : Os_types.userid -> Os_user.t Lwt.t
 
 [%%client.start]
 
 val get_data_rpc' : unit
 
-val get_data : Os_user.id -> Os_user.t Lwt.t
+val get_data : Os_types.userid -> Os_user.t Lwt.t
 
 [%%shared.start]
 

--- a/src/os_user_proxy.eliomi
+++ b/src/os_user_proxy.eliomi
@@ -19,30 +19,26 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-[%%shared.start]
-
-type userid = int64 [@@deriving json]
-
 [%%server.start]
 
-val cache : (userid, Os_user.t) Eliom_cscache.t
+val cache : (Os_types.userid, Os_types.user) Eliom_cscache.t
 
-val get_data_from_db : 'a -> Os_types.userid -> Os_user.t Lwt.t
+val get_data_from_db : 'a -> Os_types.userid -> Os_types.user Lwt.t
 
-val get_data : Os_types.userid -> Os_user.t Lwt.t
+val get_data : Os_types.userid -> Os_types.user Lwt.t
 
-val get_data_from_db_for_client : 'a -> Os_types.userid -> Os_user.t Lwt.t
+val get_data_from_db_for_client : 'a -> Os_types.userid -> Os_types.user Lwt.t
 
-val get_data_rpc' : Os_types.userid -> Os_user.t Lwt.t
+val get_data_rpc' : Os_types.userid -> Os_types.user Lwt.t
 
 [%%client.start]
 
 val get_data_rpc' : unit
 
-val get_data : Os_types.userid -> Os_user.t Lwt.t
+val get_data : Os_types.userid -> Os_types.user Lwt.t
 
 [%%shared.start]
 
-val get_data_rpc : (userid, Os_user.t) Eliom_client.server_function
+val get_data_rpc : (Os_types.userid, Os_types.user) Eliom_client.server_function
 
-val get_data_from_cache : userid -> Os_user.t Lwt.t
+val get_data_from_cache : Os_types.userid -> Os_types.user Lwt.t

--- a/src/os_userbox.eliomi
+++ b/src/os_userbox.eliomi
@@ -54,7 +54,7 @@ val upload_pic_link :
      * Html_types.button_content_fun Eliom_content.Html.D.Raw.elt list
   -> (unit -> unit) Eliom_client_value.t
   -> uploader
-  -> Os_user.id
+  -> Os_types.userid
   -> [> `A of Html_types.a_content ] Eliom_content.Html.D.Raw.elt
 
 (** Link to start to see the help from the begining.

--- a/src/os_userbox.eliomi
+++ b/src/os_userbox.eliomi
@@ -26,7 +26,7 @@ type uploader = (unit,unit) Ot_picture_uploader.service
 
 (** Box for connected users, with picture, name, and menu *)
 val connected_user_box :
-  Os_user.t -> uploader -> [> Html_types.div ] Eliom_content.Html.D.elt
+  Os_types.user -> uploader -> [> Html_types.div ] Eliom_content.Html.D.elt
 
 (** Connection box *)
 val connection_box :
@@ -35,7 +35,7 @@ val connection_box :
 (** Connected user box or connexion box, depending whether user
     is connected or not *)
 val userbox :
-  Os_user.t option ->
+  Os_types.user option ->
   uploader ->
   [> Html_types.div ] Eliom_content.Html.D.elt Lwt.t
 
@@ -66,7 +66,7 @@ val reset_tips_link :
 
 (** Display user menu *)
 val user_menu :
-  Os_user.t ->
+  Os_types.user ->
   uploader -> [> Html_types.div ] Eliom_content.Html.F.elt
 
 
@@ -75,7 +75,7 @@ val user_menu :
 (** Personnalize user menu *)
 val set_user_menu :
   ((unit -> unit) ->
-   Os_user.t ->
+   Os_types.user ->
    uploader ->
    Html_types.div_content Eliom_content.Html.D.elt
      Eliom_content.Html.D.list_wrap) ->

--- a/src/os_view.eliomi
+++ b/src/os_view.eliomi
@@ -155,7 +155,7 @@ val home_button :
 
     @param user the user. *)
 val avatar :
-  Os_user.t ->
+  Os_types.user ->
   [> `I | `Img ] Eliom_content.Html.F.elt
 
 (** [username user] creates a div with class "os_username" containing:
@@ -167,7 +167,7 @@ val avatar :
 
     @param user the user. *)
 val username :
-  Os_user.t ->
+  Os_types.user ->
   [> Html_types.div ] Eliom_content.Html.F.elt
 
 (** [password_form ~a ~service ()] defines a POST form with two inputs for a

--- a/template.distillery/PROJECT_NAME_container.eliomi
+++ b/template.distillery/PROJECT_NAME_container.eliomi
@@ -6,7 +6,7 @@
 val navigation_bar : unit -> [> `Ul ] Eliom_content.Html.F.elt Lwt.t
 
 val os_header :
-  ?user:Os_user.t ->
+  ?user:Os_types.user ->
   unit -> [> Html_types.nav ] Eliom_content.Html.F.elt Lwt.t
 
 val os_footer : unit -> [> `Footer ] Eliom_content.Html.F.elt
@@ -14,7 +14,7 @@ val os_footer : unit -> [> `Footer ] Eliom_content.Html.F.elt
 val connected_welcome_box :
   unit -> [> Html_types.div ] Eliom_content.Html.F.elt Lwt.t
 
-val get_user_data : Os_types.userid option -> Os_user.t option Lwt.t
+val get_user_data : Os_types.userid option -> Os_types.user option Lwt.t
 
 val page :
   Os_types.userid option ->

--- a/template.distillery/PROJECT_NAME_container.eliomi
+++ b/template.distillery/PROJECT_NAME_container.eliomi
@@ -14,10 +14,10 @@ val os_footer : unit -> [> `Footer ] Eliom_content.Html.F.elt
 val connected_welcome_box :
   unit -> [> Html_types.div ] Eliom_content.Html.F.elt Lwt.t
 
-val get_user_data : Os_user.id option -> Os_user.t option Lwt.t
+val get_user_data : Os_types.userid option -> Os_user.t option Lwt.t
 
 val page :
-  Os_user.id option ->
+  Os_types.userid option ->
   [< Html_types.div_content_fun > `Div ] Eliom_content.Html.F.elt
   Eliom_content.Html.F.list_wrap ->
   [> `Div | `Footer | `Nav ] Eliom_content.Html.F.elt list Lwt.t

--- a/template.distillery/PROJECT_NAME_handlers.eliom
+++ b/template.distillery/PROJECT_NAME_handlers.eliom
@@ -2,7 +2,6 @@
    Feel free to use it, modify it, and redistribute it as you wish. *)
 
 [%%shared
-  open Eliom_content.Html
   open Eliom_content.Html.F
 ]
 
@@ -54,7 +53,7 @@ let%shared action_link_handler myid_o akey () =
   (* We try first the default actions (activation link, reset password) *)
   try%lwt Os_handlers.action_link_handler myid_o akey () with
   | Os_handlers.Custom_action_link
-      ({ Os_types.userid; email; validity = _;
+      ({ Os_types.userid = _; email; validity = _;
          action = _; data = _; autoconnect = _ }, phantom_user) ->
     (* Define here your custom action links.
        If phantom_user is true, it means the link has been created for

--- a/template.distillery/PROJECT_NAME_handlers.eliom
+++ b/template.distillery/PROJECT_NAME_handlers.eliom
@@ -54,7 +54,7 @@ let%shared action_link_handler myid_o akey () =
   (* We try first the default actions (activation link, reset password) *)
   try%lwt Os_handlers.action_link_handler myid_o akey () with
   | Os_handlers.Custom_action_link
-      ({ Os_data.userid; email; validity = _;
+      ({ Os_types.userid; email; validity = _;
          action = _; data = _; autoconnect = _ }, phantom_user) ->
     (* Define here your custom action links.
        If phantom_user is true, it means the link has been created for

--- a/template.distillery/PROJECT_NAME_handlers.eliomi
+++ b/template.distillery/PROJECT_NAME_handlers.eliomi
@@ -13,7 +13,7 @@
     saved and the old is removed.
   *)
 val upload_user_avatar_handler :
-  Os_user.id ->
+  Os_types.userid ->
   unit ->
   unit *
     ((float * float * float * float) option * Ocsigen_extensions.file_info) ->
@@ -35,7 +35,7 @@ val forgot_password_handler :
   unit -> string -> unit Lwt.t
 
 val action_link_handler :
-  Os_user.id option ->
+  Os_types.userid option ->
   string -> unit -> %%%MODULE_NAME%%%_base.App.result Lwt.t
 
 (** Handler to set a new password. It uses the default OS handler
@@ -56,13 +56,13 @@ val preregister_handler : unit -> string -> unit Lwt.t
 
 (** This is the main handler, the first page of the application. *)
 val main_service_handler :
-  Os_user.id option ->
+  Os_types.userid option ->
   unit ->
   unit -> [> `Div | `Footer | `Nav ] Eliom_content.Html.F.elt list Lwt.t
 
 (** This is the handler for the about service. *)
 val about_handler :
-  Os_user.id option ->
+  Os_types.userid option ->
   unit ->
   unit -> [> `Div | `Footer | `Nav ] Eliom_content.Html.F.elt list Lwt.t
 
@@ -70,6 +70,6 @@ val about_handler :
     {!%%%MODULE_NAME%%%_container.get_user_data}), a settings container will be
     created. *)
 val settings_handler :
-  Os_user.id option ->
+  Os_types.userid option ->
   unit ->
   unit -> [> `Div | `Footer | `Nav ] Eliom_content.Html.F.elt list Lwt.t

--- a/template.distillery/PROJECT_NAME_page.eliomi
+++ b/template.distillery/PROJECT_NAME_page.eliomi
@@ -65,8 +65,8 @@ val page :
 module Opt :
   sig
     val connected_page :
-      ?allow:Os_group.t list ->
-      ?deny:Os_group.t list ->
+      ?allow:Os_types.group list ->
+      ?deny:Os_types.group list ->
       ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
       ?fallback:
       (
@@ -87,8 +87,8 @@ module Opt :
       Html_types.html Eliom_content.Html.elt Lwt.t
 
     val connected_page_full :
-      ?allow:Os_group.t list ->
-      ?deny:Os_group.t list ->
+      ?allow:Os_types.group list ->
+      ?deny:Os_types.group list ->
       ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
       ?fallback:(Os_types.userid option ->
                  'a -> 'b -> exn -> Os_page.content Lwt.t) ->
@@ -97,8 +97,8 @@ module Opt :
   end
 
 val connected_page :
-  ?allow:Os_group.t list ->
-  ?deny:Os_group.t list ->
+  ?allow:Os_types.group list ->
+  ?deny:Os_types.group list ->
   ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
   ?fallback:(Os_types.userid option ->
              'a ->
@@ -110,8 +110,8 @@ val connected_page :
   'a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t
 
 val connected_page_full :
-  ?allow:Os_group.t list ->
-  ?deny:Os_group.t list ->
+  ?allow:Os_types.group list ->
+  ?deny:Os_types.group list ->
   ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
   ?fallback:(Os_types.userid option -> 'a -> 'b -> exn -> Os_page.content Lwt.t) ->
   (Os_types.userid -> 'a -> 'b -> Os_page.content Lwt.t) ->

--- a/template.distillery/PROJECT_NAME_page.eliomi
+++ b/template.distillery/PROJECT_NAME_page.eliomi
@@ -23,7 +23,8 @@ module Page_config :
       ('a -> 'b -> exn -> Os_page.content Lwt.t) option
 
     val default_connected_error_page_full :
-      (Os_user.id option -> 'a -> 'b -> exn -> Os_page.content Lwt.t) option
+      (Os_types.userid option -> 'a -> 'b -> exn -> Os_page.content Lwt.t)
+      option
 
     val title : string
 
@@ -42,7 +43,7 @@ module Page_config :
       'b ->
       exn -> [> `Div | `Footer | `Nav ] Eliom_content.Html.F.elt list Lwt.t
     val default_connected_error_page :
-      Os_user.id option ->
+      Os_types.userid option ->
       'a ->
       'b ->
       exn -> [> `Div | `Footer | `Nav ] Eliom_content.Html.F.elt list Lwt.t
@@ -56,7 +57,8 @@ val page :
   ?predicate:('a -> 'b -> bool Lwt.t) ->
   ?fallback:('a ->
              'b ->
-             exn -> Html_types.body_content Eliom_content.Html.elt list Lwt.t) ->
+             exn ->
+             Html_types.body_content Eliom_content.Html.elt list Lwt.t) ->
   ('a -> 'b -> Html_types.body_content Eliom_content.Html.elt list Lwt.t) ->
   'a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t
 
@@ -65,17 +67,17 @@ module Opt :
     val connected_page :
       ?allow:Os_group.t list ->
       ?deny:Os_group.t list ->
-      ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
+      ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
       ?fallback:
       (
-        Os_user.id option ->
+        Os_types.userid option ->
         'a ->
         'b ->
         exn ->
         Html_types.body_content Eliom_content.Html.elt list Lwt.t
       ) ->
       (
-        Os_user.id option ->
+        Os_types.userid option ->
         'a ->
         'b ->
         Html_types.body_content Eliom_content.Html.elt list Lwt.t
@@ -87,29 +89,30 @@ module Opt :
     val connected_page_full :
       ?allow:Os_group.t list ->
       ?deny:Os_group.t list ->
-      ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
-      ?fallback:(Os_user.id option ->
+      ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
+      ?fallback:(Os_types.userid option ->
                  'a -> 'b -> exn -> Os_page.content Lwt.t) ->
-      (Os_user.id option -> 'a -> 'b -> Os_page.content Lwt.t) ->
+      (Os_types.userid option -> 'a -> 'b -> Os_page.content Lwt.t) ->
       'a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t
   end
 
 val connected_page :
   ?allow:Os_group.t list ->
   ?deny:Os_group.t list ->
-  ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
-  ?fallback:(Os_user.id option ->
+  ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
+  ?fallback:(Os_types.userid option ->
              'a ->
              'b ->
-             exn -> Html_types.body_content Eliom_content.Html.elt list Lwt.t) ->
-  (Os_user.id ->
+             exn ->
+             Html_types.body_content Eliom_content.Html.elt list Lwt.t) ->
+  (Os_types.userid ->
    'a -> 'b -> Html_types.body_content Eliom_content.Html.elt list Lwt.t) ->
   'a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t
 
 val connected_page_full :
   ?allow:Os_group.t list ->
   ?deny:Os_group.t list ->
-  ?predicate:(Os_user.id option -> 'a -> 'b -> bool Lwt.t) ->
-  ?fallback:(Os_user.id option -> 'a -> 'b -> exn -> Os_page.content Lwt.t) ->
-  (Os_user.id -> 'a -> 'b -> Os_page.content Lwt.t) ->
+  ?predicate:(Os_types.userid option -> 'a -> 'b -> bool Lwt.t) ->
+  ?fallback:(Os_types.userid option -> 'a -> 'b -> exn -> Os_page.content Lwt.t) ->
+  (Os_types.userid -> 'a -> 'b -> Os_page.content Lwt.t) ->
   'a -> 'b -> Html_types.html Eliom_content.Html.elt Lwt.t

--- a/template.distillery/PROJECT_NAME_userbox.eliomi
+++ b/template.distillery/PROJECT_NAME_userbox.eliomi
@@ -4,7 +4,7 @@
 [%%shared.start]
 
 val connected_user_box :
-  Os_user.t -> [> Html_types.div ] Eliom_content.Html.D.elt
+  Os_types.user -> [> Html_types.div ] Eliom_content.Html.D.elt
 
 val connection_box :
   unit -> [> Html_types.div ] Eliom_content.Html.D.elt Lwt.t
@@ -13,4 +13,4 @@ val msg :
   unit -> [> Html_types.div ] Eliom_content.Html.D.elt
 
 val userbox :
-  Os_user.t option -> [> Html_types.div ] Eliom_content.Html.F.elt Lwt.t
+  Os_types.user option -> [> Html_types.div ] Eliom_content.Html.F.elt Lwt.t


### PR DESCRIPTION
Instead of using `int64` in `Os_db.mli` as a user ID, it's better to use something like `Os_types.userid`. With this method, `Os_db.mli` can be compiled independently from `Os_user.eliomi`, we don't have compilation loops and we have a clearer interface.
In the future, any ID or any types used in many modules can be put in `os_types.eliom` for the same reason.

So I moved:
- `Os_user.id` --> `Os_types.userid`
- `Os_user.t` --> `Os_types.user`
- `Os_group.id` --> `Os_types.groupid`
- `Os_group.t` --> `Os_types.group`

I'm not sure the second and the fourth are useful (because the types are not abstract) so I did a different commit if the majority thinks `Os_user.t` and `Os_group.t` are better.

There's no `eliomi` file because it would be the same.