### PR TITLE
Remove 'empty' user from Os_user

### DIFF
--- a/src/os_user.eliom
+++ b/src/os_user.eliom
@@ -113,13 +113,6 @@ let password_set userid =
 
 *)
 
-let empty = {
-  userid = 0L;
-  fn = "";
-  ln = "";
-  avatar = None;
-}
-
 (** Create new user. May raise [Already_exists] *)
 let create ?password ?avatar ~firstname ~lastname email =
   try%lwt


### PR DESCRIPTION
I don't know what it is used for. It's not exported in the interface so I supposed it was only for internal uses but nothing is using it in  `Os_db`. Any explanation? Instead of an issue, I propose the PR directly if there is no reason.