### PR TITLE
Move update_main_email, is_email_validated and remove_email_from_user in lib

### DIFF
--- a/src/os_current_user.eliom
+++ b/src/os_current_user.eliom
@@ -70,8 +70,8 @@ let get_current_user_option () =
   | CU_idontknown -> failwith please_use_connected_fun
   | CU_notconnected -> None
 
-
-let%shared get_current_userid () = Os_user.userid_of_user (get_current_user ())
+let%shared get_current_userid () =
+  Os_user.userid_of_user (get_current_user ())
 
 [%%shared
   module Opt = struct
@@ -86,7 +86,8 @@ let%shared get_current_userid () = Os_user.userid_of_user (get_current_user ())
   end
 ]
 
-let%client _ = Os_session.get_current_userid_o := Opt.get_current_userid
+let%client _ =
+  Os_session.get_current_userid_o := Opt.get_current_userid
 
 let set_user_server myid =
   let%lwt u = Os_user.user_of_userid myid in
@@ -139,3 +140,36 @@ let () =
   Os_session.on_denied_request (fun _ ->
     Lwt_log.ign_debug ~section "denied request action";
     Lwt.return ())
+
+let%server remove_email_from_user email =
+  let myid = get_current_userid () in
+  Os_user.remove_email_from_user ~userid:myid ~email
+
+let%client remove_email_from_user email =
+  ~%(Eliom_client.server_function
+      [%derive.json: string]
+      (Os_session.connected_wrapper remove_email_from_user)
+  )
+  email
+
+let%server update_main_email email =
+  let myid = get_current_userid () in
+  Os_user.update_main_email ~userid:myid ~email
+
+let%client update_main_email email =
+  ~%(Eliom_client.server_function
+      [%derive.json: string]
+      (Os_session.connected_wrapper update_main_email)
+  )
+  email
+
+let%server is_email_validated email =
+  let myid = get_current_userid () in
+  Os_user.is_email_validated ~userid:myid ~email
+
+let%client is_email_validated email =
+  ~%(Eliom_client.server_function
+      [%derive.json: string]
+      (Os_session.connected_wrapper is_email_validated)
+  )
+  email

--- a/src/os_current_user.eliomi
+++ b/src/os_current_user.eliomi
@@ -44,6 +44,27 @@ module Opt : sig
   val get_current_userid : unit -> Os_user.id option
 end
 
+(** [remove_email_from_user email] removes the email [email] of the current
+    user.
+    If no user is connected, it fails with {!Os_session.Not_connected}. If
+    [email] is the main email of the current user, it fails with
+    {!Os_db.Main_email_removal_attempt}.
+ *)
+val remove_email_from_user : string -> unit Lwt.t
+
+(** [update_main_email email] sets the main email of the current user to
+    [email].
+    If no user is connected, it fails with {!Os_session.Not_connected}.
+ *)
+val update_main_email : string -> unit Lwt.t
+
+(** [is_email_validated email] returns [true] if [email] is a valided email for
+    the current user.
+    If no user is connected, it fails with {!Os_session.Not_connected}.
+    It returns [false] in all other cases.
+ *)
+val is_email_validated : string -> bool Lwt.t
+
 [%%client.start]
 
 val me : current_user ref


### PR DESCRIPTION
I extract these functions with the following idea about module hierarchy:
- `Os_db` is only for low-level functions which do raw requests to database. Nothing more. No check.
- `Os_user` is a module which wraps the database functions by adding some exception or by doing some checks (if user exists, etc) before calling functions from `Os_db`. No RPC must be written here because the functions will need the userid and we don't want to have the userid client-side.
- `Os_current_user` contains functions related to the current user and the end-user must use these functions if he needs to update or remove an email. Functions defined in this file must not contained the userid in these signature but must retrieve it to call the appropriate functions in `Os_user`.
The client and server functions must have the same signature to be able to use the function in a shared section like
```OCaml
let%shared f x =
  (* some instructions *)
  Os_current_user.g x
```
and hence the end-user doesn't need to do different functions for client and server.

`Os_session.connected_wrapper` is used instead of `Os_session.connected_rpc` because `Os_session.connected_rpc` do requests to the database to get the user.

In a next PR, I will generalize the idea of this structure if everyone agree with it.

I don't think it's used in bs (except maybe `is_email_validated`) because I think the multi-mail is not already deployed. @pwbs Could you confirm?