### PR TITLE
simplified notification interface

### DIFF
--- a/src/os_notif.eliom
+++ b/src/os_notif.eliom
@@ -180,9 +180,11 @@ VVV See if it is still needed
         id
         (Lwt.return ())
 
-  let receive_broadcast id content = (* remote invocation *)
-    notify_worker ~notforme:false id (`Concrete content)
+  (* remote invocation *)
+  let receive_broadcast ~notforme id content =
+    notify_worker ~notforme id (`Concrete content)
 
+  (* local invocation *)
   let notify ?broadcast ?(notforme = false) id content_gen = Lwt.async @@ fun () ->
     match broadcast with
     | None -> (* local invocation *)
@@ -191,7 +193,7 @@ VVV See if it is still needed
         let%lwt content = content_gen None in
         match content with
         | None -> Lwt.return ()
-        | Some content -> broadcast id content
+        | Some content -> broadcast ~notforme id content
 
   let client_ev () =
     let (ev, _, _) = Eliom_reference.Volatile.get notif_e in

--- a/src/os_notif.eliom
+++ b/src/os_notif.eliom
@@ -28,7 +28,7 @@
    We also record all opened mainboxes.
 *)
 
-module type T = sig
+module type S = sig
   type key
   type server_notif
   type client_notif

--- a/src/os_notif.eliom
+++ b/src/os_notif.eliom
@@ -162,38 +162,20 @@ VVV See if it is still needed
               let uc = Eliom_reference.Volatile.Ext.get state userchannel2 in
               I.remove uc id))
 
-  (* used by notify (local invocation) and receive_broadcast (remote invocation) *)
-  let notify_worker ~notforme id content =
+  let notify ?(notforme = false) id content_gen =
+    Lwt.async (fun () ->
       I.fold (* on all tabs registered on this data *)
         (fun (userid_o, ((_, _, send_e) as nn)) (beg : unit Lwt.t) ->
            if notforme && nn == Eliom_reference.Volatile.get notif_e
            then Lwt.return ()
            else
              let%lwt () = beg in
-             let%lwt content = match content with
-             | `Generate content_gen -> content_gen userid_o
-             | `Concrete content -> content
-             in
+             let%lwt content = content_gen userid_o in
              match content with
              | Some content -> send_e (id, content); Lwt.return ()
              | None -> Lwt.return ())
         id
-        (Lwt.return ())
-
-  (* remote invocation *)
-  let receive_broadcast ~notforme id content =
-    notify_worker ~notforme id (`Concrete content)
-
-  (* local invocation *)
-  let notify ?broadcast ?(notforme = false) id content_gen = Lwt.async @@ fun () ->
-    match broadcast with
-    | None -> (* local invocation *)
-        notify_worker ~notforme id (`Generate content_gen)
-    | Some broadcast ->
-        let%lwt content = content_gen None in
-        match content with
-        | None -> Lwt.return ()
-        | Some content -> broadcast ~notforme id content
+        (Lwt.return ()))
 
   let client_ev () =
     let (ev, _, _) = Eliom_reference.Volatile.get notif_e in

--- a/src/os_notif.eliom
+++ b/src/os_notif.eliom
@@ -28,12 +28,29 @@
    We also record all opened mainboxes.
 *)
 
+module type T = sig
+  type key
+  type server_notif
+  type client_notif
+
+  val listen : key -> unit
+  val unlisten : key -> unit
+  val unlisten_user :
+    ?sitedata:Eliom_common.sitedata -> userid:Os_user.id -> key -> unit
+  val notify : ?notforme:bool -> key -> server_notif -> unit
+  val client_ev : unit -> (key * client_notif) Eliom_react.Down.t
+end
+
 module Make(A : sig
       type key
       type server_notif
       type client_notif
       val prepare : int64 option -> server_notif -> client_notif option Lwt.t
     end) = struct
+
+	type key = A.key
+	type server_notif = A.server_notif
+	type client_notif = A.client_notif
 
   module Notif_hastbl =
     Hashtbl.Make(struct type t = A.key
@@ -190,12 +207,8 @@ VVV See if it is still needed
 
 end
 
-module Simple(A : sig
-      type key
-      type notification
-    end) =
-
-  Make (struct
+module Simple(A : sig type key type notification end) = Make
+	(struct
     type key = A.key
     type server_notif = A.notification
     type client_notif = A.notification

--- a/src/os_notif.eliomi
+++ b/src/os_notif.eliomi
@@ -56,6 +56,8 @@ module type S = sig
   val unlisten_user :
     ?sitedata:Eliom_common.sitedata -> userid:Os_user.id -> key -> unit
 
+  (*TODO: explain, why we have two types of keys. move documentation about [f]
+          to [prepare] *)
   (** Call [notify id f] to send a notification to all clients currently
       listening on data [key]. The notification is build using function [f],
       that takes the userid as parameter, if a user is connected for this
@@ -65,11 +67,12 @@ module type S = sig
       for example because he is not allowed to see this data,
       make function [f] return [None].
 
+      (*TODO: adapt documentation to notfor*)
       If [~notforme] is [true], notification will not be sent to the tab
       currently doing the request (the one which caused the notification to
       happen). Default is [false].
   *)
-  val notify : ?notforme:bool -> key -> server_notif -> unit
+  val notify : ?notfor:[`Me | `User of Os_user.id] -> key -> server_notif -> unit
 
   (** Returns the client react event. Map a function on this event to react
       to notifications from the server.

--- a/src/os_notif.eliomi
+++ b/src/os_notif.eliomi
@@ -55,7 +55,8 @@ sig
 
   (** handles notifications received as a broadcast from another server
   *)
-  val receive_broadcast : A.key -> A.notification option Lwt.t -> unit Lwt.t
+  val receive_broadcast : notforme:bool ->
+    A.key -> A.notification option Lwt.t -> unit Lwt.t
 
   (** Call [notify id f] to send a notification to all clients currently
       listening on data [key]. The notification is build using function [f],
@@ -79,7 +80,7 @@ sig
       generator, so this might break some applications!
   *)
   val notify :
-    ?broadcast:(A.key -> A.notification -> unit Lwt.t) ->
+    ?broadcast:(notforme:bool -> A.key -> A.notification -> unit Lwt.t) ->
     ?notforme:bool -> A.key -> (int64 option -> A.notification option Lwt.t) ->
     unit
 

--- a/src/os_notif.eliomi
+++ b/src/os_notif.eliomi
@@ -53,11 +53,6 @@ sig
   val unlisten_user :
     ?sitedata:Eliom_common.sitedata -> userid:Os_user.id -> A.key -> unit
 
-  (** handles notifications received as a broadcast from another server
-  *)
-  val receive_broadcast : notforme:bool ->
-    A.key -> A.notification option Lwt.t -> unit Lwt.t
-
   (** Call [notify id f] to send a notification to all clients currently
       listening on data [key]. The notification is build using function [f],
       that takes the userid as parameter, if a user is connected for this
@@ -70,19 +65,9 @@ sig
       If [~notforme] is [true], notification will not be sent to the tab
       currently doing the request (the one which caused the notification to
       happen). Default is [false].
-
-      If a function [broadcast] is supplied then instead of handling the
-      notification [notify] feeds its message to that function, which is
-      supposed to broadcast the message to other servers. See also
-      [receive_broadcast] which handles broadcast messages. Note, that the
-      transport between servers is not supplied by this module. Note also that
-      the [broadcast] function always supplies [None] to the messages content
-      generator, so this might break some applications!
   *)
-  val notify :
-    ?broadcast:(notforme:bool -> A.key -> A.notification -> unit Lwt.t) ->
-    ?notforme:bool -> A.key -> (int64 option -> A.notification option Lwt.t) ->
-    unit
+  val notify : ?notforme:bool -> A.key ->
+    (int64 option -> A.notification option Lwt.t) -> unit
 
   (** Returns the client react event. Map a function on this event to react
       to notifications from the server.

--- a/src/os_notif.eliomi
+++ b/src/os_notif.eliomi
@@ -40,7 +40,7 @@
     be updated every time the client is notified.
 *)
 
-module type T = sig
+module type S = sig
 
   type key
   type server_notif
@@ -95,7 +95,7 @@ module Make (A : sig
       type client_notif
       val prepare : int64 option -> server_notif -> client_notif option Lwt.t
     end) :
-	T with type key = A.key
+	S with type key = A.key
      and type server_notif = A.server_notif
      and type client_notif = A.client_notif
 
@@ -103,6 +103,6 @@ module Simple (A : sig
       type key
       type notification
     end) :
-	T with type key = A.key
+	S with type key = A.key
      and type server_notif = A.notification
      and type client_notif = A.notification

--- a/src/os_notif.eliomi
+++ b/src/os_notif.eliomi
@@ -40,8 +40,12 @@
     be updated every time the client is notified.
 *)
 
-module Make(A : sig type key type notification end) :
-sig
+module Make(A : sig
+      type key
+      type server_notif
+      type client_notif
+      val prepare : int64 option -> server_notif -> client_notif option Lwt.t
+    end) : sig
 
   (** Make client process listen on data whose index is [key] *)
   val listen : A.key -> unit
@@ -66,8 +70,7 @@ sig
       currently doing the request (the one which caused the notification to
       happen). Default is [false].
   *)
-  val notify : ?notforme:bool -> A.key ->
-    (int64 option -> A.notification option Lwt.t) -> unit
+  val notify : ?notforme:bool -> A.key -> A.server_notif -> unit
 
   (** Returns the client react event. Map a function on this event to react
       to notifications from the server.
@@ -82,6 +85,18 @@ sig
 ]
 
   *)
-  val client_ev : unit -> (A.key * A.notification) Eliom_react.Down.t
+  val client_ev : unit -> (A.key * A.client_notif) Eliom_react.Down.t
 
+end
+
+module Simple(A : sig
+      type key
+      type notification
+    end) : sig
+  val listen : A.key -> unit
+  val unlisten : A.key -> unit
+  val unlisten_user :
+    ?sitedata:Eliom_common.sitedata -> userid:int64 -> A.key -> unit
+  val notify : ?notforme:bool -> A.key -> A.notification -> unit
+  val client_ev : unit -> (A.key * A.notification) Eliom_react.Down.t
 end


### PR DESCRIPTION
- split notification type into a server type and a client type
- don't display notification for your own chat messages (works now also for multi-server set-up)