### PR TITLE
Push notifications: GCM --> FCM and parse the response.

### DIFF
--- a/src/os_lib.eliom
+++ b/src/os_lib.eliom
@@ -30,3 +30,18 @@ let%shared memoizator f =
       let%lwt value = f () in
       value_ref := Some value;
       Lwt.return value
+
+[%%server.start]
+module Http =
+  struct
+    let string_of_stream ?(len=16384) contents =
+      Lwt.try_bind
+        (fun () ->
+           Ocsigen_stream.string_of_stream len (Ocsigen_stream.get contents))
+        (fun r ->
+           let%lwt () = Ocsigen_stream.finalize contents `Success in
+           Lwt.return r)
+        (fun e ->
+           let%lwt () = Ocsigen_stream.finalize contents `Failure in
+           Lwt.fail e)
+  end

--- a/src/os_lib.eliomi
+++ b/src/os_lib.eliomi
@@ -31,3 +31,9 @@ val memoizator :
   (unit -> 'a Lwt.t)  ->
   unit                ->
   'a Lwt.t
+
+[%%server.start]
+module Http :
+  sig
+    val string_of_stream : ?len:int -> string Ocsigen_stream.t -> string Lwt.t
+  end

--- a/src/os_lib.eliomi
+++ b/src/os_lib.eliomi
@@ -33,7 +33,11 @@ val memoizator :
   'a Lwt.t
 
 [%%server.start]
+(** This module contains functions about HTTP request. *)
 module Http :
   sig
+    (** [string_of_stream ?len stream] creates a string of maximum length [len]
+        (default is [16384]) from the stream [stream].
+     *)
     val string_of_stream : ?len:int -> string Ocsigen_stream.t -> string Lwt.t
   end

--- a/src/os_push_notifications.eliom
+++ b/src/os_push_notifications.eliom
@@ -170,7 +170,7 @@ module Response =
         | Unregistered_device
         | Invalid_package_name
         | Authentication_failed
-        | Mismatched_sender_id
+        | Mismatch_sender_id
         | Invalid_JSON
         | Message_too_big
         | Invalid_data_key
@@ -191,7 +191,7 @@ module Response =
         | (200, "NotRegistered")             -> Unregistered_device
         | (200, "InvalidPackageName")        -> Invalid_package_name
         | (401, _)                           -> Authentication_failed
-        | (200, "MismatchSenderId")          -> Mismatched_sender_id
+        | (200, "MismatchSenderId")          -> Mismatch_sender_id
         | (400, _)                           -> Invalid_JSON
         | (200, "MessageTooBig")             -> Message_too_big
         | (200, "InvalidDataKey")            -> Invalid_data_key
@@ -211,7 +211,7 @@ module Response =
         | Unregistered_device          -> "Unregistered device"
         | Invalid_package_name         -> "Invalid package name"
         | Authentication_failed        -> "Authentication failed"
-        | Mismatched_sender_id         -> "Mismatched sender ID"
+        | Mismatch_sender_id           -> "Mismatch sender ID"
         | Invalid_JSON                 -> "Invalid JSON"
         | Message_too_big              -> "Message too big"
         | Invalid_data_key             -> "Invalid data key"

--- a/src/os_push_notifications.eliom
+++ b/src/os_push_notifications.eliom
@@ -188,12 +188,13 @@ module Response =
         let error_of_string_and_code = function
         | (200, "MissingRegistration")       -> Missing_registration
         | (200, "InvalidRegistration")       -> Invalid_registration
-        | (200, "UnregisteredDevice")        -> Unregistered_device
+        | (200, "NotRegistered")             -> Unregistered_device
         | (200, "InvalidPackageName")        -> Invalid_package_name
         | (401, _)                           -> Authentication_failed
         | (200, "MismatchSenderId")          -> Mismatched_sender_id
         | (400, _)                           -> Invalid_JSON
         | (200, "MessageTooBig")             -> Message_too_big
+        | (200, "InvalidDataKey")            -> Invalid_data_key
         | (200, "InvalidTtl")                -> Invalid_time_to_live
         | (code, "Unavailable")
             when code = 200 ||

--- a/src/os_push_notifications.eliomi
+++ b/src/os_push_notifications.eliomi
@@ -20,8 +20,9 @@
 
 (** Send push notifications to mobile clients.
 
-    This module provides a simple OCaml interface to Google Cloud Messaging
-    (GCM) to send push notifications to mobile devices. It is recommended to use
+    This module provides a simple OCaml interface to Firebase Cloud Messaging
+    (FCM) to send push notifications to mobile devices by using downstream HTTP
+    messages in JSON. It is recommended to use
     https://github.com/dannywillems/ocaml-cordova-plugin-push client-side to
     receive push notifications on the mobile.
 
@@ -29,11 +30,11 @@
     https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md
 
     Before using this module, you need to register your mobile application in
-    GCM and save the server key GCM will give you. You need to pass this key to
+    FCM and save the server key FCM will give you. You need to pass this key to
     {!send} when you want to send a notification.
 
-    On the client, you will need first to register the device on GCM and save
-    server-side the registered ID returned by GCM. You will use this ID when you
+    On the client, you will need first to register the device on FCM and save
+    server-side the registered ID returned by FCM. You will use this ID when you
     will want to send a notification to the device. This step is described in
     the binding to the Cordova plugin phonegap-plugin-push available at this
     address: https://github.com/dannywillems/ocaml-cordova-plugin-push.
@@ -67,10 +68,10 @@
     >> %}
 *)
 
-exception GCM_empty_response
-exception GCM_no_json_response of string
-exception GCM_missing_field of string
-exception GCM_unauthorized
+exception FCM_empty_response
+exception FCM_no_json_response of string
+exception FCM_missing_field of string
+exception FCM_unauthorized
 
 (** This module provides a interface to create notifications and add payloads *)
 module Notification :
@@ -204,6 +205,22 @@ module Response :
   sig
     module Results :
       sig
+        (** The type representing a success result.
+            If no error occured, the JSON in the results attribute contains a
+            mandatory field [message_id] and an optional field
+            [registration_id].
+         *)
+        type success
+
+        (** [message_id_of_success success] returns a string specifying a unique
+            ID for each successfully processed message. *)
+        val message_id_of_success : success -> string
+
+        (** [registration_id_of_t result] returns a string specifying the
+            canonical registration token for the client app that the message was
+            processed and sent to. *)
+        val registration_id_of_success : success -> string option
+
         type error =
         | Missing_registration
         | Invalid_registration
@@ -223,32 +240,17 @@ module Response :
 
         val string_of_error : error -> string
 
-        (** The type representing a success result.
-            If no error occured, the JSON in the results attribute contains a
-            mandatory field [message_id] and an optional field
-            [registration_id].
-         *)
-        type success
-
         (** The type representing a result. *)
         type t = Success of success | Error of error
 
-        (** [message_id_of_success success] returns a string specifying a unique
-            ID for each successfully processed message. *)
-        val message_id_of_success : success -> string
-
-        (** [registration_id_of_t result] returns a string specifying the
-            canonical registration token for the client app that the message was
-            processed and sent to. *)
-        val registration_id_of_success : success -> string option
       end
-    (** The type representing a GCM response *)
+    (** The type representing a FCM response *)
     type t
 
     (** [multicast_id_of_t response] returns the unique ID identifying the
         multicast message.
 
-        NOTE: In GCM documentation, it is defined as a number but the ID is
+        NOTE: In FCM documentation, it is defined as a number but the ID is
         sometimes too big to be considered as an OCaml integer.
      *)
     val multicast_id_of_t : t -> string

--- a/src/os_push_notifications.eliomi
+++ b/src/os_push_notifications.eliomi
@@ -40,6 +40,9 @@
     with ocsigen-start, you can use one of these plugins.
     - cordova-plugin-fcm (binding ocaml-cordova-plugin-fcm).
     - phonegap-plugin-push (binding ocaml-cordova-plugin-push-notifications).
+    If you use one of them and if you want to add extra data, you need to
+    use {!Data.add_raw_string} or {!Data.add_raw_json} depending on the type of
+    the value.
 
     FCM works with tokens which represents a device. This token is used to
     target the device when you send a notification. The token is retrieved
@@ -119,6 +122,9 @@ module Notification :
         On Android, the activity [activity] with a matching intent filter is
         launched when user clicks the notification.
         It corresponds to category in the APNs payload.
+
+        For Android devices, "FCM_PLUGIN_ACTIVITY" is mandatory to open the
+        application when the user touchs the notification.
      *)
     val add_click_action : string -> t -> t
 
@@ -148,6 +154,10 @@ module Notification :
 
         (** [add_tag tag notification] indicates whether each notification
             results in a new entry in the notification drawer on Android.
+            If two notifications has the same tag, the last one will replace the
+            first one.
+            Two different tags produce two different notifications in the
+            notification area.
          *)
         val add_tag : string -> t -> t
 
@@ -181,12 +191,16 @@ module Data :
     val add_raw_json : string -> Yojson.Safe.json -> t -> t
 
     (** The Cordova plugin phonegap-plugin-push interprets some payloads defined
-        in the Data key. The following module defines an interface to these
+        in the data key. The following module defines an interface to these
         payloads.
         You can find the payloads list here:
           https://github.com/phonegap/phonegap-plugin-push/blob/v2.0.x/docs/PAYLOAD.md
         Be aware that if you use this plugin, all attributes must be added in
         the data object and not in the notification object which must be empty.
+
+        Another difference is that by default with the phonegap plugin, a new
+        notification replaces the last one, which is not the case for
+        cordova-plugin-fcm. See {!add_notification_id} for more information.
      *)
     module PhoneGap :
       sig

--- a/src/os_push_notifications.eliomi
+++ b/src/os_push_notifications.eliomi
@@ -218,7 +218,12 @@ module Response :
 
         (** [registration_id_of_t result] returns a string specifying the
             canonical registration token for the client app that the message was
-            processed and sent to. *)
+            processed and sent to.
+            A value will be returned by FCM if the registration ID of the device
+            you sent the notification to has changed. The value will be the new
+            registration ID and must be used to send new notifications. If you
+            don't change the ID, you will receive the error NotRegistered.
+          *)
         val registration_id_of_success : success -> string option
 
         type error =

--- a/src/os_push_notifications.eliomi
+++ b/src/os_push_notifications.eliomi
@@ -232,7 +232,7 @@ module Response :
         | Unregistered_device
         | Invalid_package_name
         | Authentication_failed
-        | Mismatched_sender_id
+        | Mismatch_sender_id
         | Invalid_JSON
         | Message_too_big
         | Invalid_data_key


### PR DESCRIPTION
It wasn't relevant to implement it before now.

I also add `string_of_stream` in the module `Os_lib` to read a response of an HTTP post request. It comes from bs.

I'm trying to test all error returned by GCM because the Google documentation is not well done. It works for the moment but I would like to test all case.

An important thing about the review it's to check if I always finalize the stream ( @vouillon ). 