### PR TITLE
Empty .depend file in template and update .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,15 +21,4 @@ local/
 META
 Makefile.depend
 
-samples/static/avatars
-samples/static/tmp
-
-# local database directory
-samples/data
-samples/local
-
-samples.distillery/local*
-samples.distillery/_*
-samples.distillery.*
-
 _opam

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ _client/
 _deps/
 _server/
 local/
+doc/client
+doc/server
 
 .*.sw*
 


### PR DESCRIPTION
- `.depend` is added in the template to avoid the warning `Makefile.os:275: .depend: No such file or directory`
- about `.gitignore`, I suppose it was old rules. Never this kind of files would be put in `template.distillery` directory now we use `eliom-distillery`.