### PR TITLE
Ios Icons generation: change order in Makefile.

### DIFF
--- a/template.distillery/Makefile.mobile
+++ b/template.distillery/Makefile.mobile
@@ -414,19 +414,19 @@ $(ANDROID_ICONS_PATH) $(IOS_ICONS_PATH):
 $(ANDROID_ICONS_PATH)/icon-%.png: $(ICON_PNG) $(ANDROID_ICONS_PATH)
 	$(convert_android) $*x$* $< $@
 
-# Simple icons (iOS)
-$(IOS_ICONS_PATH)/icon-%.png: $(ICON_PNG) $(IOS_ICONS_PATH)
-	$(convert_ios) $*x$* $< $@
+# Triple size icons (iOS)
+$(IOS_ICONS_PATH)/icon-%@3x.png: $(ICON_PNG) $(IOS_ICONS_PATH)
+	size=$$((3 * $*)) ;\
+	$(convert_ios) $${size}x$${size} $< $@
 
 # Double size icons (iOS)
 $(IOS_ICONS_PATH)/icon-%@2x.png: $(ICON_PNG) $(IOS_ICONS_PATH)
 	size=$$((2 * $*)) ;\
 	$(convert_ios) $${size}x$${size} $< $@
 
-# Triple size icons (iOS)
-$(IOS_ICONS_PATH)/icon-%@3x.png: $(ICON_PNG) $(IOS_ICONS_PATH)
-	size=$$((3 * $*)) ;\
-	$(convert_ios) $${size}x$${size} $< $@
+# Simple icons (iOS)
+$(IOS_ICONS_PATH)/icon-%.png: $(ICON_PNG) $(IOS_ICONS_PATH)
+	$(convert_ios) $*x$* $< $@
 
 # iOS icons with special names
 # To add one, use a rule like this:


### PR DESCRIPTION
because the first `icon-%` was used instead of `icon-%2x`.

It caused bad icons generation.