### PR TITLE
Update API

### DIFF
--- a/src/os_comet.eliom
+++ b/src/os_comet.eliom
@@ -46,7 +46,10 @@ let%client _ = Eliom_comet.set_handle_exn_function
 *)
 
 [%%shared
-  type msg = Connection_changed | Heartbeat
+(** The type of sent message *)
+type msg =
+  | Connection_changed (** If a connection changed *)
+  | Heartbeat (** Just to be sure the server is not down. *)
 ]
 
 let create_monitor_channel () =

--- a/src/os_comet.eliomi
+++ b/src/os_comet.eliomi
@@ -19,26 +19,23 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** This module provides function to monitor communications between the server
+    clients.
+    It's only defined for internal uses so not a lot of things are exported.
+ *)
+
 [%%shared.start]
 val __link : unit
 
-type msg = Connection_changed | Heartbeat
-
 [%%client.start]
 
+(** [restart_process ()] restarts the client.
+    For mobile application, it restarts the application by going to
+    ["index.html"].
+    For other types of clients, <<a_api subproject="server" |
+    module Eliom_service.reload_action>> is used as argument of <<a_api
+    subproject="server" | module Eliom_client.exit_to>>
+ *)
 val restart_process :
   unit ->
   unit
-
-val handle_message : msg Lwt_stream.result -> unit Lwt.t
-
-[%%server.start]
-
-val create_monitor_channel :
-  unit -> 'a Eliom_comet.Channel.t * ('a option -> unit)
-
-val monitor_channel_ref :
-  (msg Eliom_comet.Channel.t * (msg option -> unit)) option
-  Eliom_reference.Volatile.eref
-
-val already_send_ref : bool Eliom_reference.Volatile.eref

--- a/src/os_current_user.eliom
+++ b/src/os_current_user.eliom
@@ -89,28 +89,28 @@ let%shared get_current_userid () =
 let%client _ =
   Os_session.get_current_userid_o := Opt.get_current_userid
 
-let set_user_server myid =
+let%server set_user_server myid =
   let%lwt u = Os_user.user_of_userid myid in
   Eliom_reference.Volatile.set me (CU_user u);
   Lwt.return ()
 
-let unset_user_server () =
+let%server unset_user_server () =
   Eliom_reference.Volatile.set me CU_notconnected
 
-let set_user_client () =
+let%server set_user_client () =
   let u = Eliom_reference.Volatile.get me in
   ignore [%client ( me := ~%u : unit)]
 
-let unset_user_client () =
+let%server unset_user_client () =
   ignore [%client ( me := CU_notconnected : unit)]
 
-let last_activity : CalendarLib.Calendar.t option Eliom_reference.eref =
+let%server last_activity : CalendarLib.Calendar.t option Eliom_reference.eref =
   Eliom_reference.eref
     ~persistent:"lastactivity"
     ~scope:Eliom_common.default_group_scope
     None
 
-let () =
+let%server () =
   Os_session.on_request (fun myid ->
     (* I initialize current user to CU_notconnected *)
     Lwt_log.ign_debug ~section "request action";

--- a/src/os_current_user.eliomi
+++ b/src/os_current_user.eliomi
@@ -18,6 +18,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** This module provides functions and types to manage the current user. *)
+
 [%%shared.start]
 
 type current_user =

--- a/src/os_date.eliomi
+++ b/src/os_date.eliomi
@@ -23,8 +23,12 @@
     This module provides some useful functions to detect and manage
     time zones, print dates, etc.
 
-    It's essentially a wrapper to CalendarLib.Calendar.t through an abstract
+    It's essentially a wrapper to {!CalendarLib.Calendar.t} through an abstract
     type and by using zone and date data provided by the browser.
+    See [calendar] OCaml library for more information about
+    [CalendarLib] module. Specifiers from [calendar] OCaml library are used:
+    refer you to the official documentation
+    (http://calendar.forge.ocamlcore.org/doc) to know the significations.
 *)
 
 [%%shared.start]
@@ -35,14 +39,22 @@ type local_calendar
 (** Convert a local calendar to a UTC calendar *)
 val to_utc : local_calendar -> CalendarLib.Calendar.t
 
-(** Convert a calendar to a local calendar. *)
+(** Convert any type of calendar to a local calendar. *)
 val to_local : CalendarLib.Calendar.t -> local_calendar
 
+(** [now ()] returns the current date as a [local_calendar] value. *)
 val now : unit -> local_calendar
 
+(** Convert a [local_calendar] value to a [CalendarLib.Time.t] value. *)
 val to_local_time : local_calendar -> CalendarLib.Time.t
+
+(** Convert a [local_calendar] value to a [CalendarLib.Date.t] value. *)
 val to_local_date : local_calendar -> CalendarLib.Date.t
+
+(** Convert a [local_calendar] value to a [CalendarLib.Calendar.t] value. *)
 val local_to_calendar : local_calendar -> CalendarLib.Calendar.t
+
+(** Convert a [CalendarLib.Calendar.t] value to a [local_calendar] value. *)
 val local_from_calendar : CalendarLib.Calendar.t -> local_calendar
 
 (** [unknown_timezone ()] returns [true] if the timezone is unknown. Else
@@ -62,30 +74,51 @@ val smart_time : ?now:local_calendar -> local_calendar -> string
     comparing to [now] (default value of now is the current time when the
     function is called).
     Smart means
-    - if [local_date] is the day before [now], Yesterday is returned.
-    - if [local_date] is the same day than [now], Today is returned.
-    - if [local_date] is the day after [now], Tomorrow is returned.
-    - In the other cases, [now] and [local_date] has the same year,
-    it returns the date in the format: %A %B %d where
-    - %A is the day name.
-    - %B is the month name.
-    - %d is day of month.
-    Else the year is added at the end.
+    - if [local_date] is the day before [now], ["Yesterday"] is returned.
+    - if [local_date] is the same day than [now], ["Today"] is returned.
+    - if [local_date] is the day after [now], ["Tomorrow"] is returned.
+    - if [now] and [local_date] has the same year, it returns the date in
+      the format: ["%A %B %d"].
+    - else the year is added at the end in the same format than the previous
+      case.
  *)
 val smart_date : ?now:local_calendar -> local_calendar -> string
 
-(** [smart_hours_minutes date] returns the time in the format %I:%M%P where
-    - %I is hour in the 12 hours format.
-    - %M is minute.
-    - %P AM or PM
+(** [smart_hours_minutes date] returns the time in the format ["%I:%M%P"].
     If the timezone is unknown, GMT is added.
  *)
 val smart_hours_minutes : local_calendar -> string
 
+(** [smart_interval ?now start_date end_date] returns a smart description of
+    [start_date] comparing to [end_date] of the year, month, day, hour and
+    minutes (compared to {!smart_date_interval}, information about the hour and
+    minutes is given).
+
+    The year is not used if [start_date] and [end_date] or if [start_date] and
+    [now] have the same year.
+
+    The final output is the concatenation of [smart_start_date] and
+    [smart_end_date] with a dash between them.
+
+    [smart_start_date] and [smart_end_date] in in the format ["%B %d, %Y"] if
+    year is needed and ["%B %d"] if not.
+ *)
 val smart_interval :
   ?now:local_calendar -> local_calendar -> local_calendar -> string
 
+(** [smart_date_interval ?now start_date end_date] returns a smart description
+    of [start_date] comparing to [end_date] of the year, month and day
+    (compared to {!smart_interval}, no information about the hour and
+    minutes is given).
+
+    The year is not used if [start_date] and [end_date] or if [start_date] and
+    [now] have the same year.
+
+    The final output is the concatenation of [smart_start_date] and
+    [smart_end_date] with a dash between them.
+    [smart_start_date] (resp. [smart_end_date]) is [start_date] (resp.
+    [end_date]) in the format ["%B %d, %Y, %I:%M%P"] if year is needed and ["%B
+    %d, %I:%M%P"] if not.
+ *)
 val smart_date_interval :
   ?now:local_calendar -> local_calendar -> local_calendar -> string
-
-

--- a/src/os_email.eliomi
+++ b/src/os_email.eliomi
@@ -23,19 +23,22 @@
 *)
 
 (** [set_from_addr (sender_name, sender_email)] sets the email address used to
-    send mail to [sender_email] and the sender name to [sender_name] *)
+    send mail to [sender_email] and the sender name to [sender_name]. *)
 val set_from_addr : (string * string) -> unit
 
 (** [set_mailer mailer] sets the name of the external [sendmail] program on your
-    system, used by the default send function. *)
+    system, used by the default {!send} function. *)
 val set_mailer : string -> unit
 
-(** [get_mailer ()] returns the name of mailer program *)
+(** [get_mailer ()] returns the name of mailer program. *)
 val get_mailer : unit -> string
 
+(** Exception raised if the mailer is invalid. You can raise an exception of
+    this type in email sending function if you use {!set_send}.
+ *)
 exception Invalid_mailer of string
 
-(** The pattern used to check the validity of an e-mail address *)
+(** The pattern used to check the validity of an e-mail address. *)
 val email_pattern : string
 
 (** [is_valid email] returns [true] if the e-mail address [email] is valid. Else
@@ -45,7 +48,7 @@ val is_valid : string -> bool
 (** Send an e-mail to [to_addrs] from [from_addr]. You have to define the
     [subject] of your email. The body of the email is a list of strings
     and each element of the list is automatically separated by a new line.
-    A tuple used by [from_addr] and [to_addrs] is of the form (name, email).
+    Tuples used by [from_addr] and [to_addrs] is of the form [(name, email)].
     *)
 val send :
   ?from_addr:(string * string) ->
@@ -54,7 +57,9 @@ val send :
   string list ->
   unit Lwt.t
 
-(** Customize email sending function. *)
+(** Customize email sending function. See {!send} for more details about the
+    arguments.
+ *)
 val set_send :
   (from_addr:(string * string) ->
    to_addrs:((string * string) list) ->

--- a/src/os_group.mli
+++ b/src/os_group.mli
@@ -23,6 +23,9 @@
     Groups are used by OS for example to restrict access to pages or
     server functions. *)
 
+(** Exception raised when no there is no group corresponding to the request (for
+    example wrong ID or name).
+ *)
 exception No_such_group
 
 (* -----------------------------------------------------------------
@@ -62,8 +65,9 @@ val group_of_name : string -> Os_types.Group.t Lwt.t
 (* -----------------------------------------------------------------
 
    All the followings functions are only helpers/wrappers around db
-   functions ones. They generally use the type [t] of the module
-   and get rid of the part of picking each field of the record [t].
+   functions ones. They generally use the type {!Os_types.group} of the module
+   and get rid of the part of picking each field of the record
+   {!os_types.group}.
 
 *)
 

--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -176,7 +176,6 @@ let%client restart ?url () =
      On a Web app, it is just reloading the page.
      On a mobile app, we want to restart from eliom.html.
   *)
-  print_endline "restarting";
   if Eliom_client.is_client_app () then
     ((match url with
        | Some url ->

--- a/src/os_handlers.eliomi
+++ b/src/os_handlers.eliomi
@@ -18,22 +18,30 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** This module contains pre-defined handlers for connect, disconnect, sign up,
+    add a new email, etc. Each handler has a corresponding service in
+    {!Os_services}.
+ *)
 [%%shared.start]
 
 (** [connect_handler () ((login, password), keepMeLoggedIn)] connects the user
     with [login] and [password] and keeps the user logged in between different
-    session if [keepMeLoggedIn] is set to [true] *)
+    session if [keepMeLoggedIn] is set to [true]. *)
 val connect_handler : unit -> (string * string) * bool -> unit Lwt.t
 
 (** [disconnect_handler ?main_page () ()] disconnects the current user. *)
 val disconnect_handler : ?main_page:bool -> unit -> unit -> unit Lwt.t
 
-(** [sign_up_handler () email] *)
+(** [sign_up_handler () email] signes up an user with email [email]. *)
 val sign_up_handler : unit -> string -> unit Lwt.t
 
 (** [add_email_handler () email] adds the email. *)
 val add_email_handler : unit -> string -> unit Lwt.t
 
+(** Exception raised when something went wrong with an action link key. The
+    action link key is given as parameter as a type
+    {!Os_types.actionlinkkey_info}.
+ *)
 exception Custom_action_link of
     Os_types.Action_link_key.info
     * bool (* If true, the link corresponds to a phantom user
@@ -49,39 +57,52 @@ exception No_such_resource
 
 [%%server.start]
 
+(** [action_link_handler userid_o activation_key ()] is the handler for
+    activation keys.
+ *)
 val action_link_handler :
   int64 option ->
   string ->
   unit ->
   'a Eliom_registration.application_content Eliom_registration.kind Lwt.t
 
-[%%client.start]
-
-val action_link_handler :
-  int64 option ->
-  string ->
-  unit ->
-  'b Eliom_registration.application_content Eliom_registration.kind Lwt.t
-
 [%%server.start]
 
+(** [forgot_password_handler service () email] creates and sends an action link
+    to [email] if the user forgot his password and redirects to [service].
+    If [email] doesn't correspond to any user, {!Os_userbox.user_does_not_exist}
+    is set to [true] and {!Os_msg.msg} is called with the level [`Err].
+ *)
 val forgot_password_handler :
   (unit, unit, Eliom_service.get, Eliom_service.att, _,
    Eliom_service.non_ext, _, _, unit, unit, 'c)
     Eliom_service.t ->
   unit -> string -> unit Lwt.t
 
+(** [preregister_handler () email] preregisters the email [email]. *)
 val preregister_handler :
   unit -> string -> unit Lwt.t
 
+(** [set_password_handler userid () (password, confirmation_password)] updates
+    the password of the user with ID [userid] with the hashed value of
+    [password] if [confirmation_password] corresponds to [password]. If they
+    don't correspond, {!Os_msg.msg} is called with the level [`Err].
+ *)
 val set_password_handler :
   Os_types.User.id -> unit -> string * string -> unit Lwt.t
 
+(** [set_personal_data_handler userid () ((firstname, lastname), (password,
+    confirmation_password))] sets the corresponding data to given values.
+ *)
 val set_personal_data_handler :
   Os_types.User.id -> unit -> (string * string) * (string * string) -> unit Lwt.t
 
 [%%client.start]
 
+(** [set_password_rpc (password, confirmation_password)] is a RPC to
+    [set_password].
+ *)
 val set_password_rpc : string * string -> unit Lwt.t
 
+(** [restart ?url ()] restarts the client and redirects to the url [url]. *)
 val restart : ?url:string -> unit -> unit

--- a/src/os_handlers.eliomi
+++ b/src/os_handlers.eliomi
@@ -49,16 +49,25 @@ exception Custom_action_link of
               In that case, you probably want to display a sign-up form,
               and in the other case a login form. *)
 
+(** Exception raised when an account has been already activated and no user is
+    connected.
+ *)
 exception Account_already_activated_unconnected of Os_types.Action_link_key.info
 
+(** Exception raised when the key is oudated. *)
 exception Invalid_action_key of Os_types.Action_link_key.info
 
+(** Exception raised when the requested resource is not available. *)
 exception No_such_resource
 
-[%%server.start]
+[%%shared.start]
 
 (** [action_link_handler userid_o activation_key ()] is the handler for
     activation keys.
+
+    Depending on the error, {!No_such_resource}, {!Custom_action_link},
+    {!Invalid_action_key} or {!Account_already_activated_unconnected} can be
+    raised.
  *)
 val action_link_handler :
   int64 option ->

--- a/src/os_lib.eliomi
+++ b/src/os_lib.eliomi
@@ -19,6 +19,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** This module aims to provide common utilities functions. *)
+
 [%%client.start]
 
 (** [reload ()] reloads the current page. *)

--- a/src/os_msg.eliomi
+++ b/src/os_msg.eliomi
@@ -18,20 +18,26 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** This module provides functions to display messages (client-side or
+    server-side).
+ *)
 [%%shared.start]
 
 (** Call this function either from client or server side
     to display an error message in the page.
-    The message is displayed in a special box (a div with id [os-msg]
-    created automatically in the body of the page if not already present).
+
+    The message is displayed in a special box (a ["div"] with id ["os_msg"]
+    created automatically in the body of the page).
+
     It is displayed during a short amount of time then disappears. You may
     change the duration in seconds with the parameter [duration] (default 2
     seconds).
-    The two levels correspond to different classes that you can
-    personalize by modifying the CSS class [os-err] (added for error messages to
-    the box with ID os-msg).
 
-    If [~onload] is [true], the message is displayed after the next page
+    The two levels correspond to different classes that you can
+    personalize by modifying the CSS class ["os_err"] (added for error messages
+    to the box with ID ["os_msg"]).
+
+    If [?onload] is [true], the message is displayed after the next page
     is displayed (default [false]). When called on server side, this is
     always the case.
 *)
@@ -45,11 +51,11 @@ val msg :
 val action_link_key_created : bool Eliom_reference.Volatile.eref
 
 (** [((firstname, lastname), (password, password_confirmation)) option]
-    This reference is used to remember information about the user during a
+    is a reference used to remember information about the user during a
     request when something went wrong (for example in a form when the password
     and password confirmation are not the same).
-    If the value is [None], no user data has been set.
-    Default is [None].
+
+    If the value is [None], no user data has been set. Default is [None].
  *)
 val wrong_pdata
   : ((string * string) * (string * string)) option Eliom_reference.Volatile.eref

--- a/src/os_notif.eliomi
+++ b/src/os_notif.eliomi
@@ -40,7 +40,7 @@
     be updated every time the client is notified.
 *)
 
-(** we have two types of notifications ([server_notif], and [client_notif])
+(*  we have two types of notifications ([server_notif], and [client_notif])
     because we might need to serialise and deserialise the notification twice.
     Once for broadcasting it to other servers (in case of a multi-server set-up)
     and once for transferring it to the client (after possibly transforming the
@@ -49,8 +49,13 @@
 *)
 module type S = sig
 
+  (** The key type. *)
   type key
+
+  (** The server notification type. Can be different from [client_notif]. *)
   type server_notif
+
+  (** The client notification type. Can be different from [server_notif]. *)
   type client_notif
 
   (** Make client process listen on data whose index is [key] *)

--- a/src/os_page.eliomi
+++ b/src/os_page.eliomi
@@ -26,9 +26,12 @@ exception Predicate_failed of (exn option)
 (** An abstract type describing the content of a page *)
 type content
 
-(** Specifies a page with an optional title, some optional extra
-    metadata and a given body. [?html_a] allows to set attributes
-    to the html tag *)
+(** Specifies a page with an optional title (with the argument [?title]), some
+    optional extra metadata (with the argument [?head]) and a given body.
+
+    [?html_a] (resp. [?a]) allows to set attributes to the html (resp. body)
+    tag.
+ *)
 val content :
   ?html_a: Html_types.html_attrib Eliom_content.Html.attrib list ->
   ?a : Html_types.body_attrib Eliom_content.Html.attrib list ->
@@ -45,43 +48,64 @@ module type PAGE = sig
       pages.  *)
   val title : string
 
-  (** [js] corresponds to the Javascript files to include into each page.
-      Os will automatically preprend the suffix "js/" as directory.  *)
+  (** [js] corresponds to the JavaScript files to include into each page.
+      Os will automatically preprend the suffix ["js/"] as directory.  *)
   val js : string list list
 
   (** Use [local_js] instead of [js] for local scripts if you are building
       a mobile application.
-      Os will automatically preprend the suffix "js/" as directory.  *)
+      Os will automatically preprend the suffix ["js/"] as directory.  *)
   val local_js : string list list
 
   (** [css] (same as [js] but for style sheet files).
-      Os will automatically prepend the suffix "css/" as directory.  *)
+      Os will automatically prepend the suffix ["css/"] as directory.  *)
   val css : string list list
 
   (** Use [local_css] instead of [css] for local stylesheets if you are building
       a mobile application.
-      Os will automatically prepend the suffix "css/" as directory.  *)
+      Os will automatically prepend the suffix ["css/"] as directory.  *)
   val local_css : string list list
 
   (** [other_head] is a list of custom elements to add in the head section.
       It can be used to add <meta> elements, for example. *)
   val other_head : Html_types.head_content_fun Eliom_content.Html.elt list
 
-  (** Default error page. *)
+  (** [default_error_page get_param post_param exn] is the default error page.
+      [get_param] (resp. [post_param]) is the GET (resp. POST) parameters sent
+      to the error page.
+
+      [exn] is the exception which must be caught when something went wrong.
+   *)
   val default_error_page : 'a -> 'b -> exn -> content Lwt.t
 
-  (** Default error page for connected pages. *)
+  (** [default_connected_error_page userid_o get_param post_param exn] is the
+      default error page for connected pages.
+   *)
   val default_connected_error_page :
     Os_types.User.id option -> 'a -> 'b -> exn -> content Lwt.t
 
-  (** Default predicate. *)
+  (** [default_predicate get_param post_param] is the default predicate. *)
   val default_predicate : 'a -> 'b -> bool Lwt.t
 
-  (** Default predicate for connected pages. *)
-  val default_connected_predicate : Os_types.User.id option -> 'a -> 'b -> bool Lwt.t
+  (** [default_connected_predicate userid_o get_param post_param] is the default
+      predicate for connected pages.
+   *)
+  val default_connected_predicate :
+    Os_types.User.id option ->
+    'a ->
+    'b ->
+    bool Lwt.t
 
 end
 
+(** A default configuration for pages.
+    - no CSS and JS files are included.
+    - no meta data are added in head
+    - error page prints debug information about the exception.
+    - a div is returned in case of an error with class ["errormsg"] containing a
+    h2 with value ["Error"] and a paragraph if the exception is
+    {!Os_session.Not_connected}.
+ *)
 module Default_config : PAGE
 
 module Make (C : PAGE) : sig

--- a/src/os_request_cache.eliomi
+++ b/src/os_request_cache.eliomi
@@ -44,6 +44,7 @@ module type Cache_sig = sig
 end
 
 
+(** Functor which creates a module {!Cache_sig}. *)
 module Make : functor
   (M : sig
 

--- a/src/os_services.eliomi
+++ b/src/os_services.eliomi
@@ -19,6 +19,10 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** This module provides pre-defined services for connect, disconnect, sign up,
+    add a new email, etc. Each service has a corresponding handler in
+    {!Os_handlers}.
+ *)
 [%%shared.start]
 
 (** The main service. *)
@@ -56,7 +60,8 @@ val preregister_service :
 
 
 (** A POST service when the user forgot his password.
-    See {!Os_handlers.forgot_password_handler} for a default handler. *)
+    See {!Os_handlers.forgot_password_handler} for a default handler.
+ *)
 val forgot_password_service :
   (
     unit,
@@ -74,7 +79,8 @@ val forgot_password_service :
 
 (** A POST service to update the basic user data like first name, last name and
     password.
-    See {!Os_handlers.set_personal_data_handler'} for a default handler. *)
+    See {!Os_handlers.set_personal_data_handler'} for a default handler.
+ *)
 val set_personal_data_service :
   (
     unit,
@@ -92,7 +98,8 @@ val set_personal_data_service :
   ) Eliom_service.t
 
 (** A POST service to sign up with only an email address.
-    See {!Os_handlers.sign_up_handler} for a default handler. *)
+    See {!Os_handlers.sign_up_handler} for a default handler.
+ *)
 val sign_up_service :
   (
     unit,
@@ -109,7 +116,8 @@ val sign_up_service :
   ) Eliom_service.t
 
 (** A POST service to connect a user with username and password.
-    See {!Os_handlers.connect_handler} for a default handler. *)
+    See {!Os_handlers.connect_handler} for a default handler.
+ *)
 val connect_service :
   (
     unit,
@@ -127,7 +135,8 @@ val connect_service :
   ) Eliom_service.t
 
 (** A POST service to disconnect the current user.
-    See {!Os_handlers.disconnect_handler} for a default handler. *)
+    See {!Os_handlers.disconnect_handler} for a default handler.
+ *)
 val disconnect_service :
   (
     unit,
@@ -146,7 +155,8 @@ val disconnect_service :
 (** A GET service for action link keys.
     See {!Os_handlers.action_link_handler} for a default handler and
     {!Os_db.action_link_table} for more information about the action
-    process. *)
+    process.
+ *)
 val action_link_service :
   (
     string,
@@ -164,7 +174,8 @@ val action_link_service :
 
 (** A POST service to update the password. An update password action is
     associated with the confirmation password.
-    See {!Os_handlers.set_password_handler'} for a default handler. *)
+    See {!Os_handlers.set_password_handler'} for a default handler.
+ *)
 val set_password_service :
   (
     unit,
@@ -182,7 +193,8 @@ val set_password_service :
   ) Eliom_service.t
 
 (** A POST service to add an email to a user.
-    See {!Os_handlers.add_email_handler} for a default handler. *)
+    See {!Os_handlers.add_email_handler} for a default handler.
+ *)
 val add_email_service :
   (
     unit,

--- a/src/os_uploader.eliomi
+++ b/src/os_uploader.eliomi
@@ -19,13 +19,15 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** This module defines functions to manipulate images to be uploaded. *)
+
 [%%server.start]
 
-(** [crop_image src dst ratio top right bottom left] crops the image saved in
-    [src] and saves the result in [dst] (default is the source file). [top],
-    [right], [bottom] and [left] are the number of pixels the image must be
-    truncated on the specific sides. The [ratio] is used after truncating
-    the image.
+(** [crop_image ~src ?dst ?ratio ~top ~right ~bottom ~left] crops the image
+    saved in [src] and saves the result in [dst] (default is the source file).
+    [top], [right], [bottom] and [left] are the number of pixels the image must
+    be truncated on the specific side. The [ratio] is used after truncating the
+    image.
  *)
 val crop_image :
   src:string ->
@@ -37,8 +39,8 @@ val crop_image :
   left:float ->
   unit Lwt.t
 
-(** [record_image directory ~ratio ~cropping:(top, right, bottom, left) file]
-    crops the image like [crop_image] and save in the directory [directory].
+(** [record_image directory ?ratio ?cropping:(top, right, bottom, left) file]
+    crops the image like [crop_image] and save it in the directory [directory].
  *)
 val record_image :
   string ->

--- a/src/os_user_proxy.eliom
+++ b/src/os_user_proxy.eliom
@@ -18,12 +18,19 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-(*VVV Warning: Os already implements a cache of user, but for
-  Os_types.User.t only. It's ok. *)
+(** This module implements a cache of user using <<a_api project="eliom" |
+    module Eliom_cscache>> which allows to keep synchronized the cache between
+    the client and the server.
+    Even if there is a cache implementing in {!Os_user} to avoid to do database
+    requests, this last one is implementing only server side.
+
+    TODO: This module must be compared to [Os_request_cache], [Eliom_cscache]
+    and [Os_user.MCache]. The idea behind these different modules must be
+    compared.
+ *)
 
 let%server cache : (Os_types.User.id, Os_types.User.t) Eliom_cscache.t =
   Eliom_cscache.create ()
-
 
 let%server get_data_from_db myid_o userid =
   Os_user.user_of_userid userid
@@ -38,9 +45,7 @@ let%server get_data_from_db_for_client myid_o userid =
 let%server get_data_rpc' =
   Os_session.Opt.connected_rpc get_data_from_db_for_client
 
-let%client get_data_rpc' = ()
-
-let get_data_rpc
+let%server get_data_rpc
   : (_, Os_types.User.t) Eliom_client.server_function =
   Eliom_client.server_function ~name:"os_user_proxy.get_data_rpc"
     [%derive.json: Os_types.User.id] get_data_rpc'

--- a/src/os_user_proxy.eliomi
+++ b/src/os_user_proxy.eliomi
@@ -19,29 +19,57 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-(** This module implements a cache of user. *)
+(** This module implements a cache of user using <<a_api project="eliom" |
+    module Eliom_cscache>> which allows to keep synchronized the cache between
+    the client and the server.
+    Even if there is a cache implemented in {!Os_user} to avoid to do database
+    requests, this last one is implementing only server side. Same for
+    {!Os_request_cache} which is also only server-side.
+ *)
 [%%server.start]
 
+(** Cache keeping userid and user information as a {!Os_types.user} type. *)
 val cache : (Os_types.User.id, Os_types.User.t) Eliom_cscache.t
 
-(** [get_data_from_db myid_o userid] *)
+(** [get_data_from_db myid_o userid] returns the user which has ID [userid].
+    For the moment, [myid_o] is not used but it will be use later.
+
+    Data comes from the database, not the cache.
+ *)
 val get_data_from_db : 'a -> Os_types.User.id -> Os_types.User.t Lwt.t
 
+(** [get_data userid] returns the user which has ID [userid].
+    For the moment, [myid_o] is not used but it will be use later.
+
+    Data comes from the database, not the cache.
+ *)
 val get_data : Os_types.User.id -> Os_types.User.t Lwt.t
 
+(** [get_data_from_db_for_client myid_o userid] returns the user which has ID
+    [userid]. For the moment, [myid_o] is not used but it will be use later.
+
+    Data comes from the database, not the cache.
+ *)
 val get_data_from_db_for_client : 'a -> Os_types.User.id -> Os_types.User.t Lwt.t
 
+(** [get_data_rpc' userid] returns the user which has ID [userid].
+    Use {!Os_connected_rpc} and {!get_data_from_db_for_client}.
+ *)
 val get_data_rpc' : Os_types.User.id -> Os_types.User.t Lwt.t
 
 [%%client.start]
-
-val get_data_rpc' : unit
 
 val get_data : Os_types.User.id -> Os_types.User.t Lwt.t
 
 [%%shared.start]
 
+(** [get_data_rpc] is a RPC to <<a_api subproject="server" | module
+    Os_user_proxy.get_data_rpc'>>
+ *)
 val get_data_rpc :
   (Os_types.User.id, Os_types.User.t) Eliom_client.server_function
 
+(** [get_data_from_cache userid] returns the user with ID [userid] saved in
+    cache.
+ *)
 val get_data_from_cache : Os_types.User.id -> Os_types.User.t Lwt.t

--- a/src/os_user_proxy.eliomi
+++ b/src/os_user_proxy.eliomi
@@ -19,10 +19,12 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** This module implements a cache of user. *)
 [%%server.start]
 
 val cache : (Os_types.User.id, Os_types.User.t) Eliom_cscache.t
 
+(** [get_data_from_db myid_o userid] *)
 val get_data_from_db : 'a -> Os_types.User.id -> Os_types.User.t Lwt.t
 
 val get_data : Os_types.User.id -> Os_types.User.t Lwt.t
@@ -39,6 +41,7 @@ val get_data : Os_types.User.id -> Os_types.User.t Lwt.t
 
 [%%shared.start]
 
-val get_data_rpc : (Os_types.User.id, Os_types.User.t) Eliom_client.server_function
+val get_data_rpc :
+  (Os_types.User.id, Os_types.User.t) Eliom_client.server_function
 
 val get_data_from_cache : Os_types.User.id -> Os_types.User.t Lwt.t

--- a/src/os_userbox.eliomi
+++ b/src/os_userbox.eliomi
@@ -24,9 +24,26 @@
 
 type uploader = (unit,unit) Ot_picture_uploader.service
 
-(** Link to upload a picture.
-    The client function given as first parameter will be called first,
-    for example to close the menu containing the link. *)
+(** [upload_pic_link ?a ?content ?crop ?input ?submit action_after_submit
+    service userid]
+
+    Creates a link with a label and a submit button to upload a picture.
+
+    The client function [action_after_submit] will be called first,
+    for example to close the menu containing the link.
+
+    You can add attributes to the HTML tag with the optional parameter [?a].
+    [?input] and [?submit] are couples [(attributes, content_children)] for the
+    label and the submit button where [attributes] is a list of attributes for
+    the tag and [content_children] is a list of children. By default, they are
+    empty.
+
+    [?content] is the link text. The default value is "Change profile picture".
+
+    [service] is the service called to upload the picture.
+
+    You can crop the picture by giving a value to [?crop].
+ *)
 val upload_pic_link :
   ?a:[< Html_types.a_attrib > `OnClick ] Eliom_content.Html.D.Raw.attrib list
   -> ?content:Html_types.a_content Eliom_content.Html.D.Raw.elt list
@@ -42,7 +59,7 @@ val upload_pic_link :
   -> Os_types.User.id
   -> [> `A of Html_types.a_content ] Eliom_content.Html.D.Raw.elt
 
-(** Link to start to see the help from the begining.
+(** Link to start to see the help from the beginning.
     The client function given as first parameter will be called first,
     for example to close the menu containing the link. *)
 val reset_tips_link :
@@ -51,9 +68,20 @@ val reset_tips_link :
 
 [%%server.start]
 
+(** Reference used to remember if a wrong password has been already typed. *)
 val wrong_password : bool Eliom_reference.Volatile.eref
+
+(** Reference used to remember if the account is activated. *)
 val account_not_activated : bool Eliom_reference.Volatile.eref
+
+(** Reference used to remember if the user already exists. *)
 val user_already_exists : bool Eliom_reference.Volatile.eref
+
+(** Reference used to remember if the user exists. *)
 val user_does_not_exist : bool Eliom_reference.Volatile.eref
+
+(** Reference used to remeber if the user is already preregistered. *)
 val user_already_preregistered : bool Eliom_reference.Volatile.eref
+
+(** Reference used to remeber if an action link key is outdated. *)
 val action_link_key_outdated : bool Eliom_reference.Volatile.eref

--- a/src/os_view.eliom
+++ b/src/os_view.eliom
@@ -150,10 +150,6 @@ let%shared information_form ?a
 let%shared preregister_form ?a label =
   generic_email_form ?a ~service:Os_services.preregister_service ~label ()
 
-(** [home_button ~a ()] creates a input button with value "home" which redirects
-    to the main service.
-
-    @param a modify the attributes of the form. *)
 let%shared home_button ?a () =
   Form.get_form ?a ~service:Os_services.main_service
     (fun _ -> [

--- a/src/os_view.eliomi
+++ b/src/os_view.eliomi
@@ -19,6 +19,12 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** This module defines functions to create password forms, connection forms,
+    settings buttons and other common contents arising in applications.
+    As Eliom_content.Html.F is opened by default, if the module D is not
+    explicitly used, HTML tags will be functional.
+ *)
+
 [%%client.start]
 
 (** [check_password_confirmation ~password ~confirmation] adds a listener to
@@ -32,19 +38,16 @@ val check_password_confirmation :
 
 [%%shared.start]
 
-(** This module defines functions to create password forms, connection forms,
-    settings buttons and other common contents arising in applications.
-    As Eliom_content.Html.F is opened by default, if the module D is not
-    explicitly used, HTML tags will be functional.
+(** [generic_email_form ?a ?label ?text ?email ~service ()] creates an email
+    POST form with an input of type email and a submit button. Placeholder value
+    ["e-mail address"] is used for the email input.
+
+    @param a add attributes of the form.
+    @param label add a label (default is [None]) to the email input.
+    @param text text for the button (default is ["Send"]).
+    @param email the default value of the email input (default is empty).
+    @param service service which the data is sent to.
  *)
-
-(** [generic_email_form ~a ~label ~text ~service ()] creates an email POST form
-    with an input of type email and a submit button.
-
-    @param a modify the attributes of the form.
-    @param label add a label (none by default) to the email input.
-    @param text text for the button ["Send" by default].
-    @param service service which the data is sent to. *)
 val generic_email_form :
   ?a:[< Html_types.form_attrib ] Eliom_content.Html.D.attrib list ->
   ?label:string Eliom_content.Html.F.wrap ->
@@ -67,19 +70,24 @@ val generic_email_form :
   unit ->
   [> Html_types.form ] Eliom_content.Html.D.elt
 
-(** [connect_form ()] creates a POST login form with email, password, a
-    checkbox to stay logged in and a submit button with default placeholders.
+(** [connect_form ?a ?email ()] creates a POST login form with email, password,
+    a checkbox to stay logged in (with default text to ["keep me logged in"] in
+    a span) and a submit button. Default placeholders for input email (resp.
+    password) is ["Your email"] (resp. ["Your password"]).
+
     The data is sent to {!Os_services.connect_service}.
 
-    @param a attributes of the form. *)
+    @param a attributes of the form.
+    @param email the default value of the email input (default is empty).
+ *)
 val connect_form :
   ?a:[< Html_types.form_attrib ] Eliom_content.Html.D.attrib list ->
   ?email:string ->
   unit ->
   [> Html_types.form ] Eliom_content.Html.D.elt
 
-(** [disconnect_button ~a ()] creates a disconnect POST form with a button
-    without value, a signout icon and a text message "logout".
+(** [disconnect_button ?a ()] creates a disconnect POST form with a button
+    without value, a signout icon and a text message ["logout"].
 
     @param a attributes of the form. *)
 val disconnect_button :
@@ -87,10 +95,12 @@ val disconnect_button :
   unit ->
   [> Html_types.form ] Eliom_content.Html.F.elt
 
-(** [sign_up_form ~a ()] creates a {!generic_email_form} with the service
+(** [sign_up_form ?a ?email ()] creates a {!generic_email_form} with the service
     {!Os_services.sign_up_service}.
 
-    @param a  attributes of the form. *)
+    @param a attributes of the form.
+    @param email the default value of the email input (default is empty).
+ *)
 val sign_up_form :
   ?a:[< Html_types.form_attrib ] Eliom_content.Html.D.attrib list ->
   ?email:string ->
@@ -100,7 +110,8 @@ val sign_up_form :
 (** [forgot_password_form ~a ()] creates a {!generic_email_form} with the
     service {!Os_services.forgot_password_service}.
 
-    @param a attributes of the form. *)
+    @param a attributes of the form.
+ *)
 val forgot_password_form :
   ?a:[< Html_types.form_attrib ] Eliom_content.Html.D.attrib list ->
   unit ->
@@ -139,8 +150,8 @@ val preregister_form :
   string Eliom_content.Html.F.wrap ->
   [> Html_types.form ] Eliom_content.Html.D.elt
 
-(** [home_button ~a ()] creates a input button with value "home" which redirects
-    to the main service.
+(** [home_button ~a ()] creates an input button with value "home" which
+    redirects to the main service.
 
     @param a attributes of the form. *)
 val home_button :
@@ -149,18 +160,18 @@ val home_button :
   [> Html_types.form ] Eliom_content.Html.F.elt
 
 (** [avatar user] creates an image HTML tag (with Eliom_content.HTML.F) with an
-    alt attribute to "picture" and with class "os_avatar". If the user has no
-    avatar, the default icon representing the user (see <<a_api
-    project="ocsigen-toolkit" | val Os_icons.F.user >>) is returned.
+    alt attribute to ["picture"] and with class ["os_avatar"]. If the user has
+    no avatar, the default icon representing the user (see <<a_api
+    project="ocsigen-toolkit" | val Ot_icons.F.user >>) is returned.
 
     @param user the user. *)
 val avatar :
   Os_types.User.t ->
   [> `I | `Img ] Eliom_content.Html.F.elt
 
-(** [username user] creates a div with class "os_username" containing:
+(** [username user] creates a div with class ["os_username"] containing:
     - [firstname] [lastname] if the user has a firstname.
-    - User [userid] else.
+    - ["User "] concatenated with the userid in other cases.
 
     FIXME/IMPROVEME: use an option for the case the user has no firstname?
     Firstname must be empty because it must be optional.
@@ -175,7 +186,7 @@ val username :
     It also checks (client-side) if the passwords match when the send button is
     pressed.
 
-    @param a modify the attributes of the form.
+    @param a attributes of the form.
     @param service service which the data is sent to. *)
 val password_form :
   ?a:[< Html_types.form_attrib ] Eliom_content.Html.D.attrib list ->


### PR DESCRIPTION
Fix #229

I pointed out that I forgot lots of things in the API in PR when I documented.
To-do:
- [x] `Os_user_proxy`
- [x] ~~`Os_tools`~~ (see my comment below)
- [x] `Os_services`: module description.
- [x] `Os_request_cache`.
- [x] ~~`Os_notif`~~ (see my comment below)
- [x] `Os_comet`: remove some useless functions I exported when I did the eliomi.

To compile the documentation (I know some people have some difficulties), you need to switch to `4.02.3`, pin `wikidoc` and install `ocsigen-start`. After that, use `make doc`.
Here a copy-past (I suppose you are in the repo ocsigen-start and in the branch of the PR):

```
opam switch wikidoc --alias-of 4.02.3
eval `opam config env`
opam pin add --no-action -y wikidoc https://github.com/ocsigen/wikidoc.git
opam pin add --no-action -y ocsigenserver https://github.com/ocsigen/ocsigenserver.git
opam pin add --no-action -y js_of_ocaml https://github.com/ocsigen/js_of_ocaml.git
opam pin add --no-action -y deriving https://github.com/ocsigen/deriving.git
opam pin add --no-action -y reactiveData https://github.com/ocsigen/reactiveData.git
opam pin add --no-action -y eliom https://github.com/ocsigen/eliom.git
opam pin add --no-action -y ocsigen-toolkit https://github.com/ocsigen/ocsigen-toolkit.git
opam pin add --no-action -y ojquery https://github.com/ocsigen/ojquery.git
opam pin add --no-action -y ocsigen-start https://github.com/ocsigen/ocsigen-start.git
opam install wikidoc ocsigen-start -y
make doc
```
