### PR TITLE
Add icons-% dependency for emulate target.

### DIFF
--- a/template.distillery/Makefile.mobile
+++ b/template.distillery/Makefile.mobile
@@ -367,7 +367,7 @@ $(RELEASE_PLATFORMS): %-release: %
 
 EMULATE_PLATFORMS := emulate-android emulate-ios
 
-$(EMULATE_PLATFORMS): emulate-%: check-app-env assets %
+$(EMULATE_PLATFORMS): emulate-%: check-app-env icons-% assets %
 	cd $(CORDOVAPATH) ;\
 	cordova emulate --nobuild $*
 


### PR DESCRIPTION
Else, res directory is copied before creating icons. It comes from a change I made some PR ago.