### PR TITLE
Remove useless icons on Android

### DIFF
--- a/template.distillery/Makefile.mobile
+++ b/template.distillery/Makefile.mobile
@@ -325,7 +325,16 @@ $(RUN_PLATFORMS): run-%: check-app-env icons-% assets %
 ##----------------------------------------------------------------------
 ## Rules for the icons and splashes generation.
 
-ANDROID_ICON_NAMES = ldpi mdpi hdpi xhdpi xxhdpi xxxhdpi
+## Android icons names. It corresponds to ldpi, mdpi, hdpi, xhdpi, xxhdpi and
+## xxxhdpi.
+ANDROID_ICON_NAMES = \
+	icon-36 \
+	icon-48 \
+	icon-72 \
+	icon-96 \
+	icon-144 \
+	icon-192
+
 ANDROID_ICONS_PATH = $(MOBILESTATICPATH)/res/android
 ANDROID_ICONS      = $(foreach name,$(ANDROID_ICON_NAMES),$(ANDROID_ICONS_PATH)/$(name).png)
 
@@ -378,14 +387,6 @@ $(IOS_ICONS_PATH)/icon-small@3x.png: $(IOS_ICONS_PATH)/icon-29@3x.png; cp $< $@
 $(IOS_ICONS_PATH)/icon.png: $(IOS_ICONS_PATH)/icon-57.png; cp $< $@
 $(IOS_ICONS_PATH)/icon@2x.png: $(IOS_ICONS_PATH)/icon-57@2x.png; cp $< $@
 $(IOS_ICONS_PATH)/icon-83.5@2x.png: $(IOS_ICONS_PATH)/icon-167.png; cp $< $@
-
-# Android icons
-$(ANDROID_ICONS_PATH)/ldpi.png: $(ANDROID_ICONS_PATH)/icon-36.png; cp $< $@
-$(ANDROID_ICONS_PATH)/mdpi.png: $(ANDROID_ICONS_PATH)/icon-48.png; cp $< $@
-$(ANDROID_ICONS_PATH)/hdpi.png: $(ANDROID_ICONS_PATH)/icon-72.png; cp $< $@
-$(ANDROID_ICONS_PATH)/xhdpi.png: $(ANDROID_ICONS_PATH)/icon-96.png; cp $< $@
-$(ANDROID_ICONS_PATH)/xxhdpi.png: $(ANDROID_ICONS_PATH)/icon-144.png; cp $< $@
-$(ANDROID_ICONS_PATH)/xxxhdpi.png: $(ANDROID_ICONS_PATH)/icon-192.png; cp $< $@
 
 # Launch images (iOS)
 # Format: SIZE.NAME

--- a/template.distillery/mobile!config.xml.in
+++ b/template.distillery/mobile!config.xml.in
@@ -22,12 +22,12 @@
         <allow-intent href="market:*" />
         <preference name="android-minSdkVersion" value="%%MOBILE_ANDROID_SDK_VERSION%%" />
 
-        <icon src="res/android/ldpi.png" density="ldpi" />
-        <icon src="res/android/mdpi.png" density="mdpi" />
-        <icon src="res/android/hdpi.png" density="hdpi" />
-        <icon src="res/android/xhdpi.png" density="xhdpi" />
-        <icon src="res/android/xxhdpi.png" density="xxhdpi" />
-        <icon src="res/android/xxxhdpi.png" density="xxxhdpi" />
+        <icon src="res/android/icon-36.png" density="ldpi" />
+        <icon src="res/android/icon-48.png" density="mdpi" />
+        <icon src="res/android/icon-72.png" density="hdpi" />
+        <icon src="res/android/icon-96.png" density="xhdpi" />
+        <icon src="res/android/icon-144.png" density="xxhdpi" />
+        <icon src="res/android/icon-192.png" density="xxxhdpi" />
     </platform>
 
     <!-- iOS settings -->


### PR DESCRIPTION
Related to https://github.com/ocsigen/ocsigen-start/issues/257.
iOS not done because I can test for the moment.