### PR TITLE
Hotfix: check_sass wasn't working.

### DIFF
--- a/template.distillery/Makefile.style
+++ b/template.distillery/Makefile.style
@@ -30,8 +30,8 @@ endef
 
 check_sass:
 ifeq ($(strip $(USE_SASS)),yes)
-ifneq ($(shell sh -c "which sass" | echo $?),'0')
-	$(error $(ERROR_SASS))
+ifeq ($(shell sass -v 2> /dev/null),)
+$(error $(ERROR_SASS))
 endif
 endif
 


### PR DESCRIPTION
The condition is based on the fact that `sass -v 2> /dev/null` will return an empty string if `sass` doesn't exist. I don't know if it's portable...

By the way, the same thing must be done in `Makefile.db` I think.