### PR TITLE
Travis integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  - OCAML_VERSION=4.02 PINS="ocsigenserver:https://github.com/ocsigen/ocsigenserver.git reactiveData:https://github.com/ocsigen/reactiveData.git eliom:https://github.com/ocsigen/eliom.git ocsigen-toolkit:https://github.com/ocsigen/ocsigen-toolkit.git" PACKAGE=ocsigen-start
+  - OCAML_VERSION=4.03 PINS="ocsigenserver:https://github.com/ocsigen/ocsigenserver.git reactiveData:https://github.com/ocsigen/reactiveData.git eliom:https://github.com/ocsigen/eliom.git ocsigen-toolkit:https://github.com/ocsigen/ocsigen-toolkit.git" PACKAGE=ocsigen-start
+  - OCAML_VERSION=4.04 PINS="ocsigenserver:https://github.com/ocsigen/ocsigenserver.git reactiveData:https://github.com/ocsigen/reactiveData.git eliom:https://github.com/ocsigen/eliom.git ocsigen-toolkit:https://github.com/ocsigen/ocsigen-toolkit.git" PACKAGE=ocsigen-start
+os:
+  - linux
+  - osx

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-#Ocsigen-start
+# Ocsigen-start [![Travis Status][travis-img]][travis]
+
+[travis]:      https://travis-ci.org/ocsigen/ocsigen-start/branches
+[travis-img]:  https://img.shields.io/travis/ocsigen/ocsigen-start/master.svg?label=travis
 
 1. [Getting started](#getting-started)
 


### PR DESCRIPTION
Fix #165.

Based on https://github.com/ocaml/ocaml-ci-scripts/blob/master/README-travis.md (thanks for this work, very useful and intuitive).

Travis integration integrates directly PR.
Travis can be used instead of Jenkins to have easier continuous integration (less configuration). Jenkins must remain to update ocsigen.org.

An Ocsigen owner must activate Travis builds (I don't have permissions as member) ( @balat, @Drup or @vouillon).

## OCaml version.
- [x] 4.02.3
- [x] 4.03.0
- [x] 4.04.0 (see issue to fix below).

## Platform.
- [x] GNU/Linux (Debian/Ubuntu)
- [x] Mac OSX (see issue to fix below)

## TO-DO
- [x] Add badges for Mac OSX and GNU/Linux for all OCaml versions.
~~- [ ] Add template compilation.~~
~~- [ ] Add a rule for documentation generation.~~

# Issues to fix:
- [x] For Mac OSX, issue with imagemagick. PR in opam repository to resolve it (https://github.com/ocaml/opam-repository/pull/7778)
- [x] For OCaml 4.04.0, issue with OPAM ssl package. See https://github.com/savonet/ocaml-ssl/issues/28. This repo can be pinned to resolve it: https://github.com/vasilisp/ocaml-ssl.
