### PR TITLE
Remove imagemagick instructions in the README and add it in OPAM file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,6 @@ opam pin add --no-action -y ocsigen-start https://github.com/ocsigen/ocsigen-sta
 opam install ocsigen-start -y
 ```
 
-Ocsigen-start depends on the [OCaml binding to ImageMagick C library](https://github.com/besport/ocaml-imagemagick) so you need to install the [C library](http://www.imagemagick.org/script/index.php).
-
-On Mac OSX, you can install it with Homebrew: `brew install imagemagick`.
-
-On Debian/Ubuntu , you can install it with apt-get: `sudo apt-get install libgraphicsmagick1-dev libmagickcore-dev`
-
-`Makefile.mobile` needs `convert` which is an ImageMagick utility. If you are on Debian/Ubuntu, you can install this utility with `sudo apt-get install imagemagick`.
-
 ###<a id="create-your-project"></a>Create your project
 ```
 eliom-distillery -name myproject -template os.pgocaml

--- a/opam/opam
+++ b/opam/opam
@@ -18,4 +18,8 @@ depends: [
   "ppx_deriving"
   "yojson"
 ]
+depexts: [
+  [["debian"] ["imagemagick"]]
+  [["ubuntu"] ["imagemagick"]]
+]
 available: [ ocaml-version >= "4.02" ]


### PR DESCRIPTION
Dev packages are installed automatically with `imagemagick` OPAM package.
On Mac OSX, `convert` is provided with homebrew package `libmagickcore-dev`.
For Ubuntu/Debian, I hope the depext install the utility.