### PR TITLE
Typo and some warnings.

### DIFF
--- a/template.distillery/PROJECT_NAME_mobile.eliom
+++ b/template.distillery/PROJECT_NAME_mobile.eliom
@@ -12,7 +12,7 @@
 (*****************************************************************************)
 
 (* This RPC is called when client application is initialized. This way, the
- * server send necessary cookies to the client (the mobile app) early on and
+ * server sends necessary cookies to the client (the mobile app) early on and
  * subsequent requests from the client will contain the proper cookies.
  *
  * The RPC is empty by default, but you can add your own actions to be

--- a/template.distillery/PROJECT_NAME_userbox.eliom
+++ b/template.distillery/PROJECT_NAME_userbox.eliom
@@ -150,4 +150,4 @@ let%shared connection_box () =
 let%shared user_box ?user () =
   match user with
   | None -> connection_box ()
-  | Some user -> Lwt.return (connected_user_box user)
+  | Some user -> Lwt.return (connected_user_box ~user)

--- a/template.distillery/demo_calendar.eliom
+++ b/template.distillery/demo_calendar.eliom
@@ -4,7 +4,6 @@
 (* Calendar demo *)
 
 [%%shared
-  open Eliom_content.Html
   open Eliom_content.Html.D
 ]
 

--- a/template.distillery/demo_timepicker.eliom
+++ b/template.distillery/demo_timepicker.eliom
@@ -2,7 +2,6 @@
    Feel free to use it, modify it, and redistribute it as you wish. *)
 
 [%%shared
-  open Eliom_content.Html
   open Eliom_content.Html.D
 ]
 
@@ -55,7 +54,7 @@ let%shared page () =
     [%client
       (Lwt.async (fun () ->
          Lwt_js_events.clicks
-           (To_dom.of_element ~%button)
+           (Eliom_content.Html.To_dom.of_element ~%button)
            (fun _ _ ->
               ~%back_f ();
               Lwt.return ()))


### PR DESCRIPTION
Some warnings are caused due to unused variable which are really used... (like `connect_form`).