### PR TITLE
OPAM depexts: ruby-sass (Ubuntu/Debian), PostgreSQL (Ubuntu/Debien/Mac OSX)

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -20,6 +20,8 @@ depends: [
 ]
 depexts: [
   [["debian"] ["imagemagick"]]
+  [["debian"] ["ruby-sass"]]
   [["ubuntu"] ["imagemagick"]]
+  [["ubuntu"] ["ruby-sass"]]
 ]
 available: [ ocaml-version >= "4.02" ]

--- a/opam/opam
+++ b/opam/opam
@@ -21,7 +21,10 @@ depends: [
 depexts: [
   [["debian"] ["imagemagick"]]
   [["debian"] ["ruby-sass"]]
+  [["debian"] ["postgresql"]]
   [["ubuntu"] ["imagemagick"]]
   [["ubuntu"] ["ruby-sass"]]
+  [["ubuntu"] ["postgresql"]]
+  [["homebrew"] ["osx"] ["postgresql"]]
 ]
 available: [ ocaml-version >= "4.02" ]


### PR DESCRIPTION
For mac, `sass` can be installed with `sudo gem install sass` (ruby is already installed with gem). I don't know if we can install it with Homebrew.

About `sassc`, it's not mandatory as `sass` is used if `sassc` is not present.