### PR TITLE
Client-side message for failed connection

### DIFF
--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -156,7 +156,25 @@ let%client sign_up_handler_rpc =
        sign_up_handler_rpc)
 
 let%client sign_up_handler () v =
-  sign_up_handler_rpc v
+  let error msg =
+    let%lwt _ =
+      Ot_popup.popup
+        ~close_button:[Eliom_content.Html.D.pcdata "close"]
+        (fun _ -> Lwt.return @@
+          Eliom_content.Html.(
+            D.div [D.pcdata msg]
+          )
+        )
+    in
+    Lwt.return ()
+  in
+  try%lwt
+    sign_up_handler_rpc v
+  with
+  | Eliom_client_value.Exception_on_server _ ->
+    error "Exception on server. Have you started the DB?"
+  | _ ->
+    error "Error submitting mail"
 
 (* Forgot password *)
 let%server forgot_password_handler service () email =


### PR DESCRIPTION
While trying to sign up, in case `sign_up_handler` fails (e.g., because the DB is not running), display a pop-up.

For now, the previous pop-up stays. To close it, the handler would need access to the corresponding `close` function, and obtaining that seems to be quite messy.

@balat will this do for now?