### PR TITLE
Fix avatar resizing

### DIFF
--- a/src/os_user_view.eliom
+++ b/src/os_user_view.eliom
@@ -169,7 +169,7 @@ let%shared home_button ?a () =
 let%shared avatar user =
   match Os_user.avatar_uri_of_user user with
   | Some src ->
-    img ~alt:"picture" ~a:[a_class ["os_avatar"]] ~src ()
+    img ~alt:"picture" ~a:[a_class ["os-avatar"]] ~src ()
   | None -> Os_icons.F.user ()
 
 let%shared username user =

--- a/src/os_user_view.eliomi
+++ b/src/os_user_view.eliomi
@@ -168,7 +168,7 @@ val home_button :
   [> Html_types.form ] Eliom_content.Html.F.elt
 
 (** [avatar user] creates an image HTML tag (with Eliom_content.HTML.F) with an
-    alt attribute to ["picture"] and with class ["os_avatar"]. If the user has
+    alt attribute to ["picture"] and with class ["os-avatar"]. If the user has
     no avatar, the default icon representing the user (see <<a_api
     project="ocsigen-toolkit" | val Ot_icons.F.user >>) is returned.
 

--- a/template.distillery/sass!os.scss
+++ b/template.distillery/sass!os.scss
@@ -277,3 +277,12 @@ a.os-page-header-app-name {
         }
     }
 }
+
+.os-avatar {
+    margin-right: 15px;
+    width: 35px;
+}
+
+.ot-dr-left .os-avatar {
+    margin-left: 16px;
+}


### PR DESCRIPTION
Depends on https://github.com/ocsigen/ocsigen-toolkit/pull/104 and https://github.com/ocsigen/ocsigen-toolkit/pull/103.
Fix #326.

~~#335 can also be merged because we don't use it anymore. Cropping is done client-side.~~

~~Cropping server-side needs the command given in #335. It is useful if we want to save the initial image server-side for example in the database or for future cropping of the same image. Not useful for first release.~~