### PR TITLE
Fix close button in bind_popup

### DIFF
--- a/src/os_user_view.eliom
+++ b/src/os_user_view.eliom
@@ -297,7 +297,7 @@ let%shared bind_popup_button
               let%lwt _ =
                 Ot_popup.popup
                   ?a:~%a
-                  ~close_button:[]
+                  ~close_button:[ Os_icons.F.close () ]
                   ~%popup_content
               in
               Lwt.return ()))


### PR DESCRIPTION
Some popups haven't a close icon due to this missing parameter.