### PR TITLE
Set default encoding when initializing the database

### DIFF
--- a/template.distillery/Makefile.db
+++ b/template.distillery/Makefile.db
@@ -98,7 +98,7 @@ $(PSQL_DIR):
 ifeq ($(LOCAL),yes)
 
 db-init: $(PSQL_DIR)
-	$(pg_ctl) initdb -D $(PSQL_DIR)
+	$(pg_ctl) initdb -o --encoding=UNICODE -D $(PSQL_DIR)
 	echo unix_socket_directories = \'/tmp\' >> $(PSQL_DIR)/postgresql.conf
 	$(pg_ctl) -o "-p $(DB_PORT)" -D $(PSQL_DIR) -l $(PSQL_LOG) start
 


### PR DESCRIPTION
So that the encodings used with 'make db-init' and 'make db-create' match.