### PR TITLE
App under path

### DIFF
--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -188,9 +188,7 @@ let%client restart ?url () =
            (Js.string url)
        | None ->
          ());
-     Eliom_client.exit_to ~absolute:false
-       ~service:(Eliom_service.static_dir ())
-       ["eliom.html"] ())
+     Dom_html.window##.location##.href := Js.string "eliom.html")
   else
     match url with
     | Some url ->

--- a/template.distillery/Makefile.mobile
+++ b/template.distillery/Makefile.mobile
@@ -88,16 +88,16 @@ endif
 
 $(APPJS): $(JS_PREFIX).js
 ifeq ($(APP_REMOTE),yes)
-	APPJS_FILE=$$(curl -s -f $(APP_SERVER)/ | cat | grep -E -o -m 1 '$(PROJECT_NAME)_[a-f0-9]*?\.js') &&\
-	curl -s -o $@ $(APP_SERVER)/$$APPJS_FILE
+	APPJS_FILE=$$(curl -s -f $(APP_SERVER)$(APP_PATH)/ | cat | grep -E -o -m 1 '$(PROJECT_NAME)_[a-f0-9]*?\.js') &&\
+	curl -s -o $@ $(APP_SERVER)$(APP_PATH)/$$APPJS_FILE
 else
 	cp -f $(WWW_PATH)/`readlink $(JS_PREFIX).js` $@
 endif
 
 $(APPCSS):
 ifeq ($(APP_REMOTE),yes)
-	APPCSS_FILE=$$(curl -s -f $(APP_SERVER)/ | cat | grep -E -o -m 1 '$(PROJECT_NAME)_[a-f0-9]*?\.css') &&\
-	curl -s -o $@ $(APP_SERVER)/css/$$APPCSS_FILE
+	APPCSS_FILE=$$(curl -s -f $(APP_SERVER)$(APP_PATH)/ | cat | grep -E -o -m 1 '$(PROJECT_NAME)_[a-f0-9]*?\.css') &&\
+	curl -s -o $@ $(APP_SERVER)$(APP_PATH)/css/$$APPCSS_FILE
 else
 	cp -f $(WWW_PATH)/css/`readlink $(CSS_PREFIX).css` $@
 endif
@@ -176,6 +176,7 @@ $(LOCAL_STATIC_FILES): $(CORDOVAPATH)/www/%: $(LOCAL_STATIC)/%
 # This rule generates the config.xml file from mobile/config.xml.in.
 $(CORDOVAPATH)/config.xml: mobile/config.xml.in $(CORDOVAPATH)
 	sed -e "s,%%APPSERVER%%,$(APP_SERVER),g" \
+	    -e "s,%%APPPATH%%,$(APP_PATH),g" \
 	    -e "s,%%APPID%%,$(MOBILE_APP_ID),g" \
 	    -e "s,%%MOBILE_APP_NAME%%,$(MOBILE_APP_NAME),g" \
 	    -e "s,%%MOBILE_APP_VERSION%%,$(MOBILE_APP_VERSION),g" \
@@ -193,6 +194,7 @@ $(CORDOVAPATH)/www/index.html: $(CORDOVAPATH) $(APPJS) mobile/index.html.in
 	HASH=$$(md5sum $(APPJS) | cut -d ' ' -f 1) && \
 	sed -e "s,%%APPNAME%%,$(PROJECT_NAME)_$$HASH,g" \
 	    -e "s,%%APPSERVER%%,$(APP_SERVER),g" \
+	    -e "s,%%APPPATH%%,$(APP_PATH),g" \
 	    -e "s,%%MOBILE_APP_NAME%%,$(MOBILE_APP_NAME),g" \
 	    mobile/index.html.in > \
 	$(CORDOVAPATH)/www/index.html
@@ -204,6 +206,7 @@ $(CORDOVAPATH)/www/eliom.html: $(CORDOVAPATH) \
 	JS_HASH=$$(md5sum $(APPJS) | cut -d ' ' -f 1) && \
 	CSS_HASH=$$(md5sum $(APPCSS) | cut -d ' ' -f 1) && \
 	sed -e "s,%%APPNAME%%,$(PROJECT_NAME)_$$JS_HASH,g" \
+	    -e "s,%%APPPATH%%,$(APP_PATH),g" \
 	    -e "s,%%PROJECTNAME%%,$(PROJECT_NAME),g" \
 	    -e "s,%%APPSERVER%%,$(APP_SERVER),g" \
 	    mobile/eliom.html.in > $@
@@ -246,6 +249,7 @@ $(CORDOVAPATH)/www/chcp.manifest: $(APPJS) $(APPCSS) \
 $(CORDOVAPATH)/www/chcp.json: mobile/chcp.json.in \
                               $(CORDOVAPATH)/www/chcp.manifest
 	sed -e "s,%%APPSERVER%%,$(APP_SERVER),g" \
+	    -e "s,%%APPPATH%%,$(APP_PATH),g" \
 	    -e "s,%%DATE%%,$(TIMESTAMP),g" \
 	    $< > $@
 

--- a/template.distillery/README.md
+++ b/template.distillery/README.md
@@ -226,6 +226,13 @@ If you only wants to build the mobile application, you can use:
 make APP_SERVER=http://${YOUR_SERVER} APP_REMOTE=no android
 ```
 
+If you want the application URL to include a path
+(`http://${YOUR_SERVER}${PATH}`),
+you need to provide an additional `APP_PATH` argument, e.g.,
+`APP_PATH=/foo`. You need to include the leading `/`, but no trailing
+`/`. You also need to modify the `%%%PROJECT_NAME%%%.conf.in` with a
+[http://ocsigen.org/ocsigenserver/manual/config#h5o-31](`<site>` tag).
+
 ## Update the mobile application.
 
 The mobile app is updated automatically at launch time, every time the

--- a/template.distillery/mobile!chcp.json.in
+++ b/template.distillery/mobile!chcp.json.in
@@ -1,5 +1,5 @@
 {
     "release": "%%DATE%%",
-    "content_url": "%%APPSERVER%%/update/%%DATE%%",
+    "content_url": "%%APPSERVER%%%%APPPATH%%/update/%%DATE%%",
     "update": "now"
 }

--- a/template.distillery/mobile!config.xml.in
+++ b/template.distillery/mobile!config.xml.in
@@ -126,7 +126,7 @@
 
     <!-- Hot Code Push settings -->
     <chcp>
-        <config-file url="%%APPSERVER%%/update/conf/chcp.json"/>
+        <config-file url="%%APPSERVER%%%%APPPATH%%/update/conf/chcp.json"/>
     </chcp>
 
     <!-- Phonegap plugin push notification settings -->

--- a/template.distillery/mobile!eliom.html.in
+++ b/template.distillery/mobile!eliom.html.in
@@ -22,7 +22,8 @@
     <link rel="stylesheet" type="text/css" href="css/%%PROJECTNAME%%.css">
     <script>
       //<![CDATA[
-      var __eliom_server = '%%APPSERVER%%';
+      var __eliom_server = '%%APPSERVER%%%%APPPATH%%';
+      var __eliom_path = '%%APPPATH%%';
       var __eliom_app_name = '%%APPNAME%%';
       // var __eliom_debug_mode = true;
       var __css_name = '%%PROJECTNAME%%.css';

--- a/template.distillery/mobile!index.html.in
+++ b/template.distillery/mobile!index.html.in
@@ -20,7 +20,7 @@
 
         <script>
           //<![CDATA[
-          var __eliom_server = '%%APPSERVER%%';
+          var __eliom_server = '%%APPSERVER%%%%APPPATH%%';
           var __eliom_html_url = 'eliom.html';
           var __eliom_app_name = '%%APPNAME%%';
           // var __eliom_use_cookie_substitutes = true; // activate if you need cookies and you're using iOS WkWebView


### PR DESCRIPTION
A set of hacks that enable us to put the application under a path.

The path needs to be provided via the command line:

```
gmake emulate-android APP_REMOTE=yes APP_SERVER=http://192.168.1.1:8080 APP_PATH=/foo
```

The `APP_PATH` must be provided with the leading slash but with no trailing slash. `APP_PATH` is entirely optional. The `.conf.in` needs to be modified manually (`<site>` tag).

There is a corresponding branch for Eliom (`app-path`).