### PR TITLE
Use ocsipersist_%%%PROJECT_NAME%%% DB for ocsipersist

### DIFF
--- a/template.distillery/Makefile.db
+++ b/template.distillery/Makefile.db
@@ -145,6 +145,7 @@ db-upgrade:
 
 db-drop:
 	dropdb $(DB_NAME)
+	dropdb ocsipersist_%%%PROJECT_NAME%%%
 
 db-psql:
 	psql $(DB_NAME)

--- a/template.distillery/PROJECT_NAME.conf.in
+++ b/template.distillery/PROJECT_NAME.conf.in
@@ -27,6 +27,7 @@
         port="%%DB_PORT%%"
         user="%%DB_USER%%"
         password="%%DB_PASSWORD%%"
+        database="ocsipersist_%%%PROJECT_NAME%%%"
       />
     </extension>
     <extension findlib-package="eliom.server">

--- a/template.distillery/PROJECT_NAME.sql
+++ b/template.distillery/PROJECT_NAME.sql
@@ -2,7 +2,7 @@
 -- Do not remove the field with a `-- DEFAULT` suffix.
 -- That's the default tables/fields needed by Ocsigen-start
 
-CREATE DATABASE ocsipersist;
+CREATE DATABASE ocsipersist_%%%PROJECT_NAME%%%;
 
 CREATE EXTENSION citext; --DEFAULT
 -- You may remove the above line if you use the type TEXT for emails instead of CITEXT


### PR DESCRIPTION
We create a project-specific database for `ocsipersist`. This suppresses warnings and prevents possible conflicts between projects.