### PR TITLE
Use externally defined settings service in action link handler

### DIFF
--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -383,14 +383,19 @@ let%server add_email_handler =
     "Welcome!\r\nTo confirm your e-mail address, \
        please click on this link: "
   in
-  let send_act =
-    send_action_link  ~autoconnect:true msg Os_services.main_service
+  let send_act () =
+    send_action_link ~autoconnect:true msg
+      (match Os_services.settings_service () with
+       | Some service ->
+         service
+       | None ->
+         Os_services.main_service)
   in
   let add_email myid () email =
     let%lwt available = Os_db.Email.available email in
     if available then
       let%lwt () = Os_db.User.add_email_to_user ~userid:myid ~email in
-      send_act email myid
+      send_act () email myid
     else begin
       Eliom_reference.Volatile.set Os_user.user_already_exists true;
       Os_msg.msg ~level:`Err ~onload:true "E-mail already exists";

--- a/src/os_services.eliom
+++ b/src/os_services.eliom
@@ -162,3 +162,14 @@ let%client action_link_service = ~%action_link_service
 let%client set_password_service = ~%set_password_service
 let%client add_email_service = ~%add_email_service
 let%client update_language_service = ~%update_language_service
+
+(* [Os_handlers.add_email_handler] needs access to the settings
+   service, but the latter needs to be defined in the template. So we
+   use the reference [settings_service_ref]. The template needs to
+   call [set_settings_service]. *)
+
+let%server settings_service_ref = ref None
+
+let%server register_settings_service s = settings_service_ref := Some s
+
+let%server settings_service () = !settings_service_ref

--- a/src/os_services.eliomi
+++ b/src/os_services.eliomi
@@ -227,3 +227,41 @@ val update_language_service :
     [ `One of string ] Eliom_parameter.param_name,
     Eliom_service.non_ocaml
   ) Eliom_service.t
+
+[%%server.start]
+
+(** Register the settings service (defined in the app rather than in
+    the OS lib) because we need to perform redirections to it. *)
+val register_settings_service :
+  (
+    unit,
+    unit,
+    Eliom_service.get,
+    Eliom_service.att,
+    Eliom_service.non_co,
+    Eliom_service.non_ext,
+    Eliom_service.reg,
+    [ `WithoutSuffix ],
+    unit,
+    unit,
+    Eliom_service.non_ocaml
+  ) Eliom_service.t ->
+  unit
+
+(**/**)
+
+val settings_service :
+  unit ->
+  (
+    unit,
+    unit,
+    Eliom_service.get,
+    Eliom_service.att,
+    Eliom_service.non_co,
+    Eliom_service.non_ext,
+    Eliom_service.reg,
+    [ `WithoutSuffix ],
+    unit,
+    unit,
+    Eliom_service.non_ocaml
+  ) Eliom_service.t option

--- a/template.distillery/PROJECT_NAME_services.eliom
+++ b/template.distillery/PROJECT_NAME_services.eliom
@@ -54,3 +54,7 @@ let%client ocsigen_service =
 
 let%client os_github_service =
   ~%os_github_service
+
+(* The OS lib needs access to the settings service to perform
+   redirections to it. We need to register it *)
+let%server () = Os_services.register_settings_service settings_service


### PR DESCRIPTION
We need this to redirect to the settings page after validating a new e-mail. For this, we need access to the settings service (defined in the template) from the lib. See the comments for details.