### PR TITLE
Fix doc header for os_handlers.

### DIFF
--- a/src/os_handlers.eliomi
+++ b/src/os_handlers.eliomi
@@ -18,11 +18,12 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+[%%shared.start]
+
 (** This module contains pre-defined handlers for connect, disconnect, sign up,
     add a new email, etc. Each handler has a corresponding service in
     {!Os_services}.
  *)
-[%%shared.start]
 
 (** [connect_handler () ((login, password), keepMeLoggedIn)] connects the user
     with [login] and [password] and keeps the user logged in between different


### PR DESCRIPTION
See http://ocsigen.org/ocsigen-start/dev/api/client/Os_handlers.
I'm not sure it's caused by the missing empty line but I remember I resolved a similar issue like that.