### PR TITLE
Lwt pre allocated threads

### DIFF
--- a/src/os_comet.eliom
+++ b/src/os_comet.eliom
@@ -35,7 +35,7 @@ let%client restart_process () =
 
 
 let%client _ = Eliom_comet.set_handle_exn_function
-    (fun ?exn () -> restart_process (); Lwt.return ())
+    (fun ?exn () -> restart_process (); Lwt.return_unit)
 
 
 
@@ -80,16 +80,16 @@ let%client handle_message = function
     Eliom_lib.debug_exn
       "Exception received on Os_comet's monitor channel: " exn;
     restart_process ();
-    Lwt.return ()
+    Lwt.return_unit
   | Lwt_stream.Value Heartbeat ->
     Eliom_lib.debug "poum";
-    Lwt.return ()
+    Lwt.return_unit
   | Lwt_stream.Value Connection_changed ->
     Os_msg.msg ~level:`Err
       "Connection has changed from outside. Program will restart.";
     let%lwt () = Lwt_js.sleep 2. in
     Eliom_client.exit_to ~service:Eliom_service.reload_action () ();
-    Lwt.return ()
+    Lwt.return_unit
 
 let _ =
   Os_session.on_start_process
@@ -100,7 +100,7 @@ let _ =
          Lwt_stream.iter_s
            handle_message
            (Lwt_stream.map_exn ~%(fst channel))) : unit)];
-       Lwt.return ());
+       Lwt.return_unit);
   let warn c =
     (* User connected or disconnected.
        I want to send the message on all tabs of the browser: *)
@@ -118,7 +118,7 @@ let _ =
              if not (v == cur) then send (Some c)
            | None -> ())
     end;
-    Lwt.return ()
+    Lwt.return_unit
   in
   let warn_connection_change _ = warn Connection_changed in
   Os_session.on_open_session warn_connection_change;

--- a/src/os_current_user.eliom
+++ b/src/os_current_user.eliom
@@ -98,7 +98,7 @@ let%client _ =
 let%server set_user_server myid =
   let%lwt u = Os_user.user_of_userid myid in
   Eliom_reference.Volatile.set me (CU_user u);
-  Lwt.return ()
+  Lwt.return_unit
 
 let%server unset_user_server () =
   Eliom_reference.Volatile.set me CU_notconnected
@@ -115,12 +115,12 @@ let%server () =
     (* I initialize current user to CU_notconnected *)
     Lwt_log.ign_debug ~section "request action";
     unset_user_server ();
-    Lwt.return ());
+    Lwt.return_unit);
   Os_session.on_start_connected_process (fun myid ->
     Lwt_log.ign_debug ~section "start connected process action";
     let%lwt () = set_user_server myid in
     set_user_client ();
-    Lwt.return ());
+    Lwt.return_unit);
   Os_session.on_connected_request (fun myid ->
     Lwt_log.ign_debug ~section "connected request action";
     set_user_server myid);
@@ -128,16 +128,16 @@ let%server () =
     Lwt_log.ign_debug ~section "pre close session action";
     unset_user_client (); (*VVV!!! will affect only current tab!! *)
     unset_user_server (); (* ok this is a request reference *)
-    Lwt.return ());
+    Lwt.return_unit);
   Os_session.on_start_process (fun () ->
     Lwt_log.ign_debug ~section "start process action";
-    Lwt.return ());
+    Lwt.return_unit);
   Os_session.on_open_session (fun _ ->
     Lwt_log.ign_debug ~section "open session action";
-    Lwt.return ());
+    Lwt.return_unit);
   Os_session.on_denied_request (fun _ ->
     Lwt_log.ign_debug ~section "denied request action";
-    Lwt.return ())
+    Lwt.return_unit)
 
 let%server remove_email_from_user email =
   let myid = get_current_userid () in

--- a/src/os_date.eliom
+++ b/src/os_date.eliom
@@ -68,7 +68,7 @@ let init_client_process_time tz =
   let tz = CalendarLib.Time_Zone.UTC_Plus tz in
   let () = Eliom_reference.Volatile.set user_tz_gr tz in
   let () = Eliom_reference.Volatile.set user_tz_sr tz in
-  Lwt.return ()
+  Lwt.return_unit
 
 let%server init_time_rpc' = init_client_process_time
 

--- a/src/os_db.ml
+++ b/src/os_db.ml
@@ -54,7 +54,7 @@ let validate db =
     lwt () = Lwt_PGOCaml.ping db in
     Lwt.return true
   with _ ->
-    Lwt.return false
+    Lwt.return_false
 
 let pool : (string, bool) Hashtbl.t Lwt_PGOCaml.t Lwt_pool.t ref =
   ref @@ Lwt_pool.create 16 ~validate connect

--- a/src/os_db.ml
+++ b/src/os_db.ml
@@ -101,7 +101,7 @@ let view_one_lwt rq =
 let view_one_opt rq =
   try_lwt
     lwt rq = rq in
-    Lwt.return (Some (view_one rq))
+    Lwt.return_some ((view_one rq))
   with No_such_resource -> Lwt.return_none
 
 module Lwt_Query = struct

--- a/src/os_db.ml
+++ b/src/os_db.ml
@@ -52,7 +52,7 @@ let connect () = Lwt_PGOCaml.connect
 let validate db =
   try_lwt
     lwt () = Lwt_PGOCaml.ping db in
-    Lwt.return true
+    Lwt.return_true
   with _ ->
     Lwt.return_false
 

--- a/src/os_db.ml
+++ b/src/os_db.ml
@@ -102,7 +102,7 @@ let view_one_opt rq =
   try_lwt
     lwt rq = rq in
     Lwt.return (Some (view_one rq))
-  with No_such_resource -> Lwt.return None
+  with No_such_resource -> Lwt.return_none
 
 module Lwt_Query = struct
   include Lwt_Query_

--- a/src/os_email.eliom
+++ b/src/os_email.eliom
@@ -67,7 +67,7 @@ let default_send ~from_addr ~to_addrs ~subject content =
         (Netsendmail.compose ~from_addr ~to_addrs ~subject content)
     in
     echo "[SUCCESS]: e-mail has been sent!";
-    Lwt.return ()
+    Lwt.return_unit
   with Netchannels.Command_failure (Unix.WEXITED 127) ->
     echo "[FAIL]: e-mail has not been sent!";
     flush ();

--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -36,7 +36,7 @@ let%server set_personal_data_handler myid ()
   if firstname = "" || lastname = "" || pwd <> pwd2
   then
     (Eliom_reference.Volatile.set Os_msg.wrong_pdata (Some pd);
-     Lwt.return ())
+     Lwt.return_unit)
   else (
     let%lwt user = Os_user.user_of_userid myid in
     let open Os_types.User in
@@ -52,7 +52,7 @@ let%server set_password_handler myid () (pwd, pwd2) =
   if pwd <> pwd2
   then
     (Os_msg.msg ~level:`Err ~onload:true "Passwords do not match";
-     Lwt.return ())
+     Lwt.return_unit)
   else (
     let%lwt user = Os_user.user_of_userid myid in
     Os_user.update' ~password:pwd user)
@@ -95,7 +95,7 @@ let%server generate_action_link_key
             text;
             act_link;
           ]
-      with _ -> Lwt.return ());
+      with _ -> Lwt.return_unit);
   act_key
 
 
@@ -120,7 +120,7 @@ let%server send_action_link
     Os_user.add_actionlinkkey
       ?autoconnect ?action ?validity ~act_key ~userid ~email ()
   in
-  Lwt.return ()
+  Lwt.return_unit
 
 (* Sign up *)
 let%server sign_up_handler () email =
@@ -146,7 +146,7 @@ let%server sign_up_handler () email =
     else begin
       Eliom_reference.Volatile.set Os_user.user_already_exists true;
       Os_msg.msg ~level:`Err ~onload:true "E-mail already exists";
-      Lwt.return ()
+      Lwt.return_unit
     end
 
 let%server sign_up_handler_rpc v =
@@ -173,7 +173,7 @@ let%server forgot_password_handler service () email =
   with Os_db.No_such_resource ->
     Eliom_reference.Volatile.set Os_user.user_does_not_exist true;
     Os_msg.msg ~level:`Err ~onload:true "User does not exist";
-    Lwt.return ()
+    Lwt.return_unit
 
 let%client restart ?url () =
   (* Restart the client.
@@ -220,7 +220,7 @@ let disconnect_handler ?(main_page = false) () () =
                                      ~service:Eliom_service.reload_action ()))
                      ()
                    : unit)];
-  Lwt.return ()
+  Lwt.return_unit
 
 let%server disconnect_handler_rpc main_page =
   disconnect_handler ~main_page () ()
@@ -245,11 +245,11 @@ let connect_handler () ((login, pwd), keepmeloggedin) =
   | Os_db.Account_not_activated ->
       Eliom_reference.Volatile.set Os_user.account_not_activated true;
       Os_msg.msg ~level:`Err ~onload:true "Account not activated";
-      Lwt.return ()
+      Lwt.return_unit
   | Os_db.No_such_resource ->
       Eliom_reference.Volatile.set Os_user.wrong_password true;
       Os_msg.msg ~level:`Err ~onload:true "Wrong password";
-      Lwt.return ()
+      Lwt.return_unit
 
 let%server connect_handler_rpc v = connect_handler () v
 
@@ -374,7 +374,7 @@ let preregister_handler () email =
    else begin
      Eliom_reference.Volatile.set Os_user.user_already_preregistered true;
      Os_msg.msg ~level:`Err ~onload:true "E-mail already preregistered";
-     Lwt.return ()
+     Lwt.return_unit
    end
 
 (* Add email *)

--- a/src/os_msg.eliom
+++ b/src/os_msg.eliom
@@ -43,14 +43,14 @@ let%shared msg
     let message_dom = To_dom.of_p (D.p ~a:[a_class c] [pcdata ~%message]) in
     Lwt.async (fun () ->
       let%lwt () =
-        if ~%onload then Eliom_client.lwt_onload () else Lwt.return ()
+        if ~%onload then Eliom_client.lwt_onload () else Lwt.return_unit
       in
       let msgbox = msgbox () in
       Eliom_lib.debug "%s" ~%message;
       Dom.appendChild msgbox message_dom;
       let%lwt () = Lwt_js.sleep ~%duration in
       Dom.removeChild msgbox message_dom;
-      Lwt.return ())
+      Lwt.return_unit)
     : unit)]
 
 let action_link_key_created =

--- a/src/os_notif.eliom
+++ b/src/os_notif.eliom
@@ -99,7 +99,7 @@ module Make_Simple (A : ARG_SIMPLE) : S
     type key = A.key
     type server_notif = A.notification
     type client_notif = A.notification
-    let prepare _ n = Lwt.return (Some n)
+    let prepare _ n = Lwt.return_some (n)
     let equal_key = (=)
     let max_resource = 1000
     let max_identity_per_resource = 10

--- a/src/os_notif.eliom
+++ b/src/os_notif.eliom
@@ -67,7 +67,7 @@ module Make(A : ARG) : S
       Eliom_state.Ext.iter_sub_states ?sitedata ~state @@ fun state ->
          (* Iterating on all client processes in session: *)
          Eliom_state.Ext.iter_sub_states ?sitedata ~state
-           (fun state -> Ext.unlisten state id; Lwt.return ())
+           (fun state -> Ext.unlisten state id; Lwt.return_unit)
 
   let notify ?notfor key notif =
     let notfor = match notfor with
@@ -82,7 +82,7 @@ module Make(A : ARG) : S
     Os_session.on_start_process init;
     (* When a user is connected (will override the previous one): *)
     Os_session.on_start_connected_process (fun _ -> init ());
-    Os_session.on_post_close_session (fun () -> deinit () ; Lwt.return ())
+    Os_session.on_post_close_session (fun () -> deinit () ; Lwt.return_unit)
 
 end
 

--- a/src/os_page.eliom
+++ b/src/os_page.eliom
@@ -84,8 +84,8 @@ let%shared content ?(html_a=[]) ?(a=[]) ?title ?(head = []) body =
       Lwt.return
         (content [div ~a:[a_class ["errormsg"]] (h2 [pcdata "Error"]::l)])
 
-    let default_predicate _ _ = Lwt.return true
-    let default_connected_predicate _ _ _ = Lwt.return true
+    let default_predicate _ _ = Lwt.return_true
+    let default_connected_predicate _ _ _ = Lwt.return_true
     let default_error_page _ _ exn = err_page exn
     let default_connected_error_page _ _ _ exn = err_page exn
 

--- a/src/os_session.eliom
+++ b/src/os_session.eliom
@@ -44,7 +44,7 @@ let (on_start_process, start_process_action) =
 (* Call this to add an action to be done
    when the process starts in connected mode, or when the user logs in *)
 let (on_start_connected_process, start_connected_process_action) =
-  let r = ref (fun _ -> Lwt.return ()) in
+  let r = ref (fun _ -> Lwt.return_unit) in
   ((fun f ->
       let oldf = !r in
       r := (fun userid -> let%lwt () = oldf userid in f userid)),
@@ -52,7 +52,7 @@ let (on_start_connected_process, start_connected_process_action) =
 
 (* Call this to add an action to be done at each connected request *)
 let (on_connected_request, connected_request_action) =
-  let r = ref (fun _ -> Lwt.return ()) in
+  let r = ref (fun _ -> Lwt.return_unit) in
   ((fun f ->
       let oldf = !r in
       r := (fun userid -> let%lwt () = oldf userid in f userid)),
@@ -60,7 +60,7 @@ let (on_connected_request, connected_request_action) =
 
 (* Call this to add an action to be done just after openning a session *)
 let (on_open_session, open_session_action) =
-  let r = ref (fun _ -> Lwt.return ()) in
+  let r = ref (fun _ -> Lwt.return_unit) in
   ((fun f ->
       let oldf = !r in
       r := (fun userid -> let%lwt () = oldf userid in f userid)),
@@ -68,7 +68,7 @@ let (on_open_session, open_session_action) =
 
 (* Call this to add an action to be done just after closing the session *)
 let (on_post_close_session, post_close_session_action) =
-  let r = ref (fun _ -> Lwt.return ()) in
+  let r = ref (fun _ -> Lwt.return_unit) in
   ((fun f ->
       let oldf = !r in
       r := (fun () -> let%lwt () = oldf () in f ())),
@@ -76,7 +76,7 @@ let (on_post_close_session, post_close_session_action) =
 
 (* Call this to add an action to be done just before closing the session *)
 let (on_pre_close_session, pre_close_session_action) =
-  let r = ref (fun _ -> Lwt.return ()) in
+  let r = ref (fun _ -> Lwt.return_unit) in
   ((fun f ->
       let oldf = !r in
       r := (fun () -> let%lwt () = oldf () in f ())),
@@ -84,7 +84,7 @@ let (on_pre_close_session, pre_close_session_action) =
 
 (* Call this to add an action to be done just before handling a request *)
 let (on_request, request_action) =
-  let r = ref (fun _ -> Lwt.return ()) in
+  let r = ref (fun _ -> Lwt.return_unit) in
   ((fun f ->
       let oldf = !r in
       r := (fun () -> let%lwt () = oldf () in f ())),
@@ -92,7 +92,7 @@ let (on_request, request_action) =
 
 (* Call this to add an action to be done just for each denied request *)
 let (on_denied_request, denied_request_action) =
-  let r = ref (fun _ -> Lwt.return ()) in
+  let r = ref (fun _ -> Lwt.return_unit) in
   ((fun f ->
       let oldf = !r in
       r := (fun userid_o -> let%lwt () = oldf userid_o in f userid_o)),
@@ -114,7 +114,7 @@ let start_connected_process uid =
   (*   Lwt.async *)
   (*     (fun () -> *)
   (*        Lwt.catch *)
-  (*          (fun () -> Lwt_stream.iter_s (fun () -> Lwt.return ()) %c) *)
+  (*          (fun () -> Lwt_stream.iter_s (fun () -> Lwt.return_unit) %c) *)
   (*          (function *)
   (*            | Eliom_comet.Process_closed -> close_client_process () *)
   (*            | e -> *)
@@ -146,7 +146,7 @@ let connect ?(expire = false) userid =
       Eliom_state.set_volatile_data_cookie_exp_date ~cookie_scope None;
       Eliom_state.set_persistent_data_cookie_exp_date ~cookie_scope None
     end else
-      Lwt.return ()
+      Lwt.return_unit
   in
   connect_string (Int64.to_string userid)
 
@@ -175,7 +175,7 @@ let check_allow_deny userid allow deny =
            let%lwt b2 = Os_group.in_group ~userid ~group () in
            Lwt.return (b && (not b2))) b l
   in
-  if b then Lwt.return ()
+  if b then Lwt.return_unit
   else begin
     let%lwt () = denied_request_action (Some userid) in
     Lwt.fail Permission_denied
@@ -251,11 +251,11 @@ let gen_wrapper ~allow ~deny
          client side process. *)
       let%lwt () = start_process_action () in
       match uid with
-      | None -> Lwt.return ()
+      | None -> Lwt.return_unit
       | Some id -> (* new client process, but already connected *)
         start_connected_process id
     end
-    else Lwt.return ()
+    else Lwt.return_unit
   in
   match uid with
   | None ->

--- a/src/os_session.eliom
+++ b/src/os_session.eliom
@@ -159,7 +159,7 @@ let disconnect () =
 
 let check_allow_deny userid allow deny =
   let%lwt b = match allow with
-    | None -> Lwt.return true (* By default allow all *)
+    | None -> Lwt.return_true (* By default allow all *)
     | Some l -> (* allow only users from one of the groups of list l *)
       Lwt_list.fold_left_s
         (fun b group ->

--- a/src/os_session.eliom
+++ b/src/os_session.eliom
@@ -200,12 +200,12 @@ let get_session () =
             (comme si de rien n'était, pom pom pom). *)
          let%lwt () = connect_volatile (Int64.to_string uid) in
          Lwt.return (Some uid)
-       | None -> Lwt.return None)
+       | None -> Lwt.return_none)
     | Some uid -> Lwt.return (Some uid)
   in
   (* Check if the user exists in the DB *)
   match uid with
-  | None -> Lwt.return None
+  | None -> Lwt.return_none
   | Some uid ->
     try%lwt
       let%lwt _user = Os_user.user_of_userid uid in
@@ -214,7 +214,7 @@ let get_session () =
     | Os_user.No_such_user ->
       (* If session exists and no user in DB, close the session *)
       let%lwt () = disconnect () in
-      Lwt.return None
+      Lwt.return_none
 
 (** The connection wrapper checks whether the user is connected,
     and calls the page generator accordingly.

--- a/src/os_session.eliom
+++ b/src/os_session.eliom
@@ -199,9 +199,9 @@ let get_session () =
             We restart the volatile session silently
             (comme si de rien n'était, pom pom pom). *)
          let%lwt () = connect_volatile (Int64.to_string uid) in
-         Lwt.return (Some uid)
+         Lwt.return_some (uid)
        | None -> Lwt.return_none)
-    | Some uid -> Lwt.return (Some uid)
+    | Some uid -> Lwt.return_some (uid)
   in
   (* Check if the user exists in the DB *)
   match uid with
@@ -209,7 +209,7 @@ let get_session () =
   | Some uid ->
     try%lwt
       let%lwt _user = Os_user.user_of_userid uid in
-      Lwt.return (Some uid)
+      Lwt.return_some (uid)
     with
     | Os_user.No_such_user ->
       (* If session exists and no user in DB, close the session *)

--- a/src/os_tips.eliom
+++ b/src/os_tips.eliom
@@ -159,7 +159,7 @@ let%shared block ?(a = []) ?(recipient = `All) ~name ~content () =
            :: c)
       in
       box_ref := Some box ;
-      Lwt.return (Some box)
+      Lwt.return_some (box)
     end
   | _ -> Lwt.return_none
 

--- a/src/os_tips.eliom
+++ b/src/os_tips.eliom
@@ -78,7 +78,7 @@ let%server () = Os_session.on_start_connected_process
        ignore [%client (
          tips_seen_client_ref := ~%tips
        : unit)];
-       Lwt.return ())
+       Lwt.return_unit)
 
 (* notify the server that a user has seen a tip *)
 let set_tip_seen (name : string) =
@@ -164,7 +164,7 @@ let%shared block ?(a = []) ?(recipient = `All) ~name ~content () =
   | _ -> Lwt.return None
 
 let%client onload_waiter () =
-  let%lwt _  = Eliom_client.lwt_onload () in Lwt.return ()
+  let%lwt _  = Eliom_client.lwt_onload () in Lwt.return_unit
 
 (* This thread is used to display only one tip at a time *)
 let%client waiter = ref (onload_waiter ())
@@ -255,7 +255,7 @@ let%client display_bubble ?(a = [])
          bec##.style##.borderLeft := Js.string "none"
     )
     arrow;
-  Lwt.return ()
+  Lwt.return_unit
 
 (* Function to be called on server to display a tip *)
 let%shared bubble
@@ -287,7 +287,7 @@ let%shared bubble
   | `Connected, Some _ ->
     let%lwt seen = get_tips_seen () in
     if Stringset.mem name seen
-    then Lwt.return ()
+    then Lwt.return_unit
     else let _ = [%client ( Lwt.async (fun () ->
       display_bubble ?a:~%a ?arrow:~%arrow
         ?top:~%top ?left:~%left ?right:~%right ?bottom:~%bottom
@@ -298,5 +298,5 @@ let%shared bubble
         ())
                             : unit)]
       in
-      Lwt.return ()
-  | _ -> Lwt.return ()
+      Lwt.return_unit
+  | _ -> Lwt.return_unit

--- a/src/os_tips.eliom
+++ b/src/os_tips.eliom
@@ -138,7 +138,7 @@ let%shared block ?(a = []) ?(recipient = `All) ~name ~content () =
   | `Connected, Some _ ->
     let%lwt seen = get_tips_seen () in
     if Stringset.mem name seen
-    then Lwt.return None
+    then Lwt.return_none
     else begin
       let box_ref = ref None in
       let close : (unit -> unit Lwt.t) Eliom_client_value.t =
@@ -161,7 +161,7 @@ let%shared block ?(a = []) ?(recipient = `All) ~name ~content () =
       box_ref := Some box ;
       Lwt.return (Some box)
     end
-  | _ -> Lwt.return None
+  | _ -> Lwt.return_none
 
 let%client onload_waiter () =
   let%lwt _  = Eliom_client.lwt_onload () in Lwt.return_unit

--- a/src/os_uploader.eliom
+++ b/src/os_uploader.eliom
@@ -42,7 +42,7 @@ let%server resize_image ~src ?(dst = src) ~width ~height =
       )
   in
   match resize_unix_result with
-  | Unix.WEXITED status_code when status_code = 0 -> Lwt.return ()
+  | Unix.WEXITED status_code when status_code = 0 -> Lwt.return_unit
   | unix_process_status -> Lwt.fail (Error_while_resizing unix_process_status)
 
 let%server get_image_width file =

--- a/src/os_user.eliom
+++ b/src/os_user.eliom
@@ -155,7 +155,7 @@ let update ?password ?avatar ?language ~firstname ~lastname userid =
              ?password ?avatar ?language ~firstname ~lastname userid
   in
   MCache.reset userid;
-  Lwt.return ()
+  Lwt.return_unit
 
 let update' ?password user =
   update
@@ -169,17 +169,17 @@ let update' ?password user =
 let update_password ~userid ~password =
   let%lwt () = Os_db.User.update_password userid password in
   MCache.reset userid;
-  Lwt.return ()
+  Lwt.return_unit
 
 let update_language ~userid ~language =
   let%lwt () = Os_db.User.update_language userid language in
   MCache.reset userid;
-  Lwt.return ()
+  Lwt.return_unit
 
 let update_avatar ~userid ~avatar =
   let%lwt () = Os_db.User.update_avatar userid avatar in
   MCache.reset userid;
-  Lwt.return ()
+  Lwt.return_unit
 
 let get_language userid =
   Os_db.User.get_language userid

--- a/src/os_user_view.eliom
+++ b/src/os_user_view.eliom
@@ -37,7 +37,7 @@ let%client check_password_confirmation ~password ~confirmation =
                  (Js.Unsafe.coerce
                     confirmation_dom)##(setCustomValidity ("Passwords do not match"))
                else (Js.Unsafe.coerce confirmation_dom)##(setCustomValidity ("")));
-            Lwt.return ()))
+            Lwt.return_unit))
 
 let%shared generic_email_form
     ?a
@@ -281,11 +281,11 @@ let%shared upload_pic_link
         (fun close -> Ot_picture_uploader.mk_form
             ~crop:~%crop ~input:~%input ~submit:~%submit
             ~after_submit:close upload_service) ;
-      Lwt.return ()
+      Lwt.return_unit
     with e ->
       Os_msg.msg ~level:`Err "Error while uploading the picture";
       Eliom_lib.debug_exn "%s" e "→ ";
-      Lwt.return () ) : _ ) ] :: a) content
+      Lwt.return_unit ) : _ ) ] :: a) content
 
 let%shared reset_tips_link
     ?(text_link="See help again from beginning")
@@ -300,7 +300,7 @@ let%shared reset_tips_link
            Eliom_client.exit_to
              ~service:Os_tips.reset_tips_service
              () ();
-           Lwt.return ()
+           Lwt.return_unit
         )));
   : unit)];
   l
@@ -324,7 +324,7 @@ let%shared bind_popup_button
                   ~close_button:[ Os_icons.F.close () ]
                   ~%popup_content
               in
-              Lwt.return ()))
+              Lwt.return_unit))
        : _)
     ]
 

--- a/template.distillery/PROJECT_NAME_container.eliom
+++ b/template.distillery/PROJECT_NAME_container.eliom
@@ -77,7 +77,7 @@ let%shared connected_welcome_box () = Eliom_content.Html.F.(
 
 let%shared get_user_data = function
   | None ->
-    Lwt.return None
+    Lwt.return_none
   | Some myid ->
     let%lwt u = Os_user_proxy.get_data myid in
     Lwt.return (Some u)

--- a/template.distillery/PROJECT_NAME_container.eliom
+++ b/template.distillery/PROJECT_NAME_container.eliom
@@ -80,7 +80,7 @@ let%shared get_user_data = function
     Lwt.return_none
   | Some myid ->
     let%lwt u = Os_user_proxy.get_data myid in
-    Lwt.return (Some u)
+    Lwt.return_some (u)
 
 let%shared page ?html_a ?a ?title ?head myid_o content =
   let%lwt me = get_user_data myid_o in

--- a/template.distillery/PROJECT_NAME_handlers.eliom
+++ b/template.distillery/PROJECT_NAME_handlers.eliom
@@ -17,7 +17,7 @@ let upload_user_avatar_handler myid () ((), (cropping, photo)) =
   let old_avatar = Os_user.avatar_of_user user in
   let%lwt () = Os_user.update_avatar ~userid:myid ~avatar in
   match old_avatar with
-  | None -> Lwt.return ()
+  | None -> Lwt.return_unit
   | Some old_avatar ->
     Lwt_unix.unlink (Filename.concat avatar_dir old_avatar )
 

--- a/template.distillery/PROJECT_NAME_language.eliom
+++ b/template.distillery/PROJECT_NAME_language.eliom
@@ -29,7 +29,7 @@ let%server update_language lang =
   ignore [%client (%%%MODULE_NAME%%%_i18n.set_language ~%lang : unit)];
   (* Update in the database if a user is connected *)
   match myid_o with
-  | None -> Lwt.return ()
+  | None -> Lwt.return_unit
   | Some userid -> Os_user.update_language ~userid ~language
 
 let%server _ =
@@ -38,7 +38,7 @@ let%server _ =
        (* Guess a default language. *)
        let%lwt lang = best_matched_language () in
        ignore (update_language lang);
-       Lwt.return ());
+       Lwt.return_unit);
   Os_session.on_start_connected_process
     (fun userid ->
        (* Set language according to user preferences. *)
@@ -55,4 +55,4 @@ let%server _ =
        in
        %%%MODULE_NAME%%%_i18n.set_language language;
        ignore [%client (%%%MODULE_NAME%%%_i18n.set_language ~%language : unit)];
-       Lwt.return ())
+       Lwt.return_unit)

--- a/template.distillery/PROJECT_NAME_mobile.eliom
+++ b/template.distillery/PROJECT_NAME_mobile.eliom
@@ -15,7 +15,7 @@ open %%%MODULE_NAME%%% (* for dependency reasons *)
    The RPC is empty by default, but you can add your own actions to be
    performed server side on first client request, if necessary. *)
 let%server init_request _myid_o () =
-  Lwt.return ()
+  Lwt.return_unit
 
 let%server init_request_rpc : (_, unit) Eliom_client.server_function =
   Eliom_client.server_function ~name:"%%%MODULE_NAME%%%_mobile.init_request"
@@ -66,7 +66,7 @@ let () =
     let%lwt _ = Lwt_js_events.onload () in
     handle_initial_url ()
   else
-    Lwt.return ()
+    Lwt.return_unit
 
 (* Reactivate comet on resume and online events *)
 
@@ -132,9 +132,9 @@ let _ =
               (Js.string "Universal links: got link") (ev##.url);
             change_page_uri (Js.to_string ev##.url)));
     Firebug.console##log (Js.string "Universal links: registered");
-    Lwt.return ()
+    Lwt.return_unit
   | None ->
-    Lwt.return ()
+    Lwt.return_unit
 
 (* Debugging *)
 

--- a/template.distillery/PROJECT_NAME_page.eliom
+++ b/template.distillery/PROJECT_NAME_page.eliom
@@ -51,9 +51,9 @@ let%shared the_local_css = [
               ] ()
       ::css_name_script@app_js
 
-    let default_predicate _ _ = Lwt.return true
+    let default_predicate _ _ = Lwt.return_true
 
-    let default_connected_predicate _ _ _ = Lwt.return true
+    let default_connected_predicate _ _ _ = Lwt.return_true
 
     let default_error_page _ _ exn =
       %%%MODULE_NAME%%%_container.page None

--- a/template.distillery/demo_calendar.eliom
+++ b/template.distillery/demo_calendar.eliom
@@ -23,7 +23,7 @@ let%client service = ~%service
 (* A reactive value containing the currently selected date *)
 let%server s, f = Eliom_shared.React.S.create None
 
-let%client action y m d = ~%f (Some (y, m, d)); Lwt.return ()
+let%client action y m d = ~%f (Some (y, m, d)); Lwt.return_unit
 
 let%shared string_of_date = function
   | Some (y, m, d) ->

--- a/template.distillery/demo_notif.eliom
+++ b/template.distillery/demo_notif.eliom
@@ -42,7 +42,7 @@ let%server notify v =
      or ~notfor:(`User myid) to avoid sending to the current user.
      (Where myid is Os_current_user.get_current_userid ())
   *)
-  Lwt.return ()
+  Lwt.return_unit
 
 (* Make [notify] available client-side *)
 let%client notify =
@@ -77,12 +77,12 @@ let%shared make_form msg f =
       let v = Js.to_string inp##.value in
       let%lwt () = ~%f v in
       inp##.value := Js.string "";
-      Lwt.return ())
+      Lwt.return_unit)
      : unit)
   ];
   Eliom_content.Html.D.div [inp; btn]
 
-let%server unlisten () = Notif.unlisten () ; Lwt.return ()
+let%server unlisten () = Notif.unlisten () ; Lwt.return_unit
 let%client unlisten =
  ~%(Eliom_client.server_function [%derive.json : unit]
       (Os_session.connected_wrapper unlisten))

--- a/template.distillery/demo_popup.eliom
+++ b/template.distillery/demo_popup.eliom
@@ -66,7 +66,7 @@ let%shared page () =
                   ~close_button:[ Os_icons.F.close () ]
                   (fun _ -> Lwt.return @@ p [%i18n demo_popup_message])
               in
-              Lwt.return ()))
+              Lwt.return_unit))
        : unit)
     ];
   (* Page elements, using module Eliom_content.Html.F

--- a/template.distillery/demo_react.eliom
+++ b/template.distillery/demo_react.eliom
@@ -33,7 +33,7 @@ let%shared make_form msg f =
       let v = Js.to_string inp##.value in
       let%lwt () = ~%f v in
       inp##.value := Js.string "";
-      Lwt.return ())
+      Lwt.return_unit)
      : unit)
   ];
   Eliom_content.Html.D.div [inp; btn]

--- a/template.distillery/demo_rpc.eliom
+++ b/template.distillery/demo_rpc.eliom
@@ -68,7 +68,7 @@ let%shared page () =
         ((fun () ->
            let%lwt v = incr_my_ref () in
            Eliom_lib.alert "Update: %d" v;
-           Lwt.return ())
+           Lwt.return_unit)
          : unit -> unit Lwt.t)
       ]
   in

--- a/template.distillery/demo_timepicker.eliom
+++ b/template.distillery/demo_timepicker.eliom
@@ -23,7 +23,7 @@ let%client service = ~%service
 
 let%server s, f = Eliom_shared.React.S.create None
 
-let%client action (h, m) = ~%f (Some (h, m)); Lwt.return ()
+let%client action (h, m) = ~%f (Some (h, m)); Lwt.return_unit
 
 let%shared string_of_time = function
   | Some (h, m) ->
@@ -61,7 +61,7 @@ let%shared page () =
            (Eliom_content.Html.To_dom.of_element ~%button)
            (fun _ _ ->
               ~%back_f ();
-              Lwt.return ()))
+              Lwt.return_unit))
        : _)
     ];
   let%lwt tr = time_reactive () in

--- a/template.distillery/mobile!eliom_loader.ml
+++ b/template.distillery/mobile!eliom_loader.ml
@@ -99,7 +99,7 @@ log "Could not get global data";
       add_retry_button wake "No connection available"
     end;
   end;
-  Lwt.return ()
+  Lwt.return_unit
 
 (* Get the URL saved in the JavaScript variables "___eliom_html_url_" defined in
  * index.html and go this location.


### PR DESCRIPTION
Using lwt's pre-allocated threads reduce a little bit the size of the code. The gain may be very negligible here, but it means less instructions, (and less allocations?), and this optimization does not obfuscate the code so I see no reason to avoid it.

Without this patch, I have this:
```
-rw-rw-r-- 1 ju ju 723287 mars   6 00:18 /tmp/os_test/local/var/www/os_test/os_test_1874e44c161083947714d322a9696a77.js
```

And with:
```
-rw-rw-r-- 1 ju ju 723216 mars   6 00:29 /tmp/os_test/local/var/www/os_test/os_test_606d6079c9ec05cd348dc33dc2132c04.js
```

Also, even if the gain is small, it teaches the users to use these threads, which can save more space/memory in larger apps (javascript size has been reduced by 1k at besport with these replacements).