### PR TITLE
Os_email.send: separate url from the rest of the content

### DIFF
--- a/src/os_email.eliom
+++ b/src/os_email.eliom
@@ -42,10 +42,17 @@ let email_regexp =
 let is_valid email =
   Str.string_match email_regexp email 0
 
-let default_send ~from_addr ~to_addrs ~subject content =
+let default_send ?url ~from_addr ~to_addrs ~subject content =
   (* TODO with fork ou mieux en utilisant l'event loop de ocamlnet *)
   let echo = printf "%s\n" in
   let flush () = printf "%!" in
+  let content =
+    match url with
+    | Some url ->
+      content @ [url]
+    | None ->
+      content
+  in
   try
     let content =
       if List.length content = 0
@@ -75,8 +82,8 @@ let default_send ~from_addr ~to_addrs ~subject content =
 
 let send_ref = ref default_send
 
-let send ?(from_addr = !from_addr) ~to_addrs ~subject content =
-  !send_ref ~from_addr ~to_addrs ~subject content
+let send ?url ?(from_addr = !from_addr) ~to_addrs ~subject content =
+  !send_ref ?url ~from_addr ~to_addrs ~subject content
 
 let set_send s = send_ref := s
 

--- a/src/os_email.eliomi
+++ b/src/os_email.eliomi
@@ -51,6 +51,7 @@ val is_valid : string -> bool
     Tuples used by [from_addr] and [to_addrs] is of the form [(name, email)].
     *)
 val send :
+  ?url:string ->
   ?from_addr:(string * string) ->
   to_addrs:((string * string) list) ->
   subject:string ->
@@ -61,7 +62,8 @@ val send :
     arguments.
  *)
 val set_send :
-  (from_addr:(string * string) ->
+  (?url:string ->
+   from_addr:(string * string) ->
    to_addrs:((string * string) list) ->
    subject:string ->
    string list ->

--- a/src/os_handlers.eliom
+++ b/src/os_handlers.eliom
@@ -91,10 +91,8 @@ let%server generate_action_link_key
         Os_email.send
           ~to_addrs:[("", email)]
           ~subject:"creation"
-          [
-            text;
-            act_link;
-          ]
+          ~url:act_link
+          [ text ]
       with _ -> Lwt.return_unit);
   act_key
 


### PR DESCRIPTION
Useful for customizing the sent e-mail.