### PR TITLE
Rename confirm_code_remind_service to confirm_code_recovery_service

### DIFF
--- a/src/os_services.eliom
+++ b/src/os_services.eliom
@@ -169,7 +169,7 @@ let confirm_code_extra_service =
     ~meth:(Eliom_service.Post (unit, string "number"))
     ()
 
-let confirm_code_remind_service =
+let confirm_code_recovery_service =
   Eliom_service.create
     ~path:Eliom_service.No_path
     ~meth:(Eliom_service.Post (unit, string "number"))
@@ -189,7 +189,7 @@ let%client update_language_service = ~%update_language_service
 
 let%client confirm_code_signup_service = ~%confirm_code_signup_service
 let%client confirm_code_extra_service  = ~%confirm_code_extra_service
-let%client confirm_code_remind_service = ~%confirm_code_remind_service
+let%client confirm_code_recovery_service = ~%confirm_code_recovery_service
 
 (* [Os_handlers.add_email_handler] needs access to the settings
    service, but the latter needs to be defined in the template. So we
@@ -201,3 +201,5 @@ let%shared settings_service_ref = ref None
 let%shared register_settings_service s = settings_service_ref := Some s
 
 let%shared settings_service () = !settings_service_ref
+
+let%shared confirm_code_remind_service = confirm_code_recovery_service

--- a/src/os_services.eliomi
+++ b/src/os_services.eliomi
@@ -258,6 +258,19 @@ val confirm_code_extra_service :
 
 (** Confirm SMS activation code and (if valid) allow the user to set a
     new password. *)
+val confirm_code_recovery_service :
+  (unit, string,
+   Eliom_service.post,
+   Eliom_service.non_att,
+   Eliom_service.co,
+   Eliom_service.non_ext,
+   Eliom_service.reg,
+   [ `WithoutSuffix ], unit,
+   [ `One of string ] Eliom_parameter.param_name,
+   Eliom_service.non_ocaml) Eliom_service.t
+
+(** Temporary alternate name for [confirm_code_recovery_handler] to
+    facilite the transition. *)
 val confirm_code_remind_service :
   (unit, string,
    Eliom_service.post,

--- a/template.distillery/PROJECT_NAME_phone_connect.eliom
+++ b/template.distillery/PROJECT_NAME_phone_connect.eliom
@@ -28,8 +28,8 @@ let () = if enable then begin
   Os_user_view.enable_phone () ;
 
   Eliom_registration.Action.register
-    ~service:Os_services.confirm_code_remind_service
-    Os_handlers.confirm_code_remind_handler ;
+    ~service:Os_services.confirm_code_recovery_service
+    Os_handlers.confirm_code_recovery_handler ;
 
   Eliom_registration.Action.register
     ~service:Os_services.confirm_code_extra_service


### PR DESCRIPTION
... with a temporary alias to facilitate transition. I will remove the alias in a few weeks.

I wanted to use "recovery" everywhere, but I forgot to rename the service.

Also fixes template compilation.