### PR TITLE
Os_db: add a database connection creation hook

### DIFF
--- a/src/os_db.mli
+++ b/src/os_db.mli
@@ -30,9 +30,13 @@ exception Main_email_removal_attempt
 (** Exception raised when the account is not activated. *)
 exception Account_not_activated
 
-(** [init ?host ?port ?user ?password ?database ?unix_domain_socket_dir ()]
-    initializes the variables for the database access.
- *)
+(** Lwt version of PGOCaml *)
+module PGOCaml : PGOCaml_generic.PGOCAML_GENERIC with type 'a monad = 'a Lwt.t
+
+(** [init ?host ?port ?user ?password ?database ?unix_domain_socket_dir ?init ()]
+    initializes the variables for the database access and register a
+    function [init] invoked each time a connection is created.
+*)
 val init :
   ?host:string ->
   ?port:int ->
@@ -41,10 +45,10 @@ val init :
   ?database:string ->
   ?unix_domain_socket_dir:string ->
   ?pool_size:int ->
+  ?init:(PGOCaml.pa_pg_data PGOCaml.t -> unit Lwt.t) ->
   unit ->
   unit
 
-module PGOCaml : PGOCaml_generic.PGOCAML_GENERIC with type 'a monad = 'a Lwt.t
 
 (** [full_transaction_block f] executes function [f] within a database
     transaction. The argument of [f] is a PGOCaml database handle. *)


### PR DESCRIPTION
During initialization, one can now specify a function to be called whenever a database connection is created.