### PR TITLE
fix: put a_onload on <body> instead of <html>

### DIFF
--- a/src/os_page.eliom
+++ b/src/os_page.eliom
@@ -136,11 +136,11 @@ let%shared content ?(html_a=[]) ?(a=[]) ?title ?(head = []) body =
         let platform = Js.string (Os_platform.css_class (Os_platform.get ())) in
         Dom_html.document##.documentElement##.classList##add(platform); : unit)]
       in
-      html ~a:(platform_attr :: content.html_attrs)
+      html ~a:(content.html_attrs)
         (Eliom_tools.F.head ~title ~css ~js
            ~other:(local_css @ local_js @ content.head @ C.other_head) ())
         (body
-          ~a:(connected_attr :: content.body_attrs)
+          ~a:(platform_attr :: connected_attr :: content.body_attrs)
           content.body
         )
 


### PR DESCRIPTION
The way page generation is implemented in `Eliom_client`, an `a_onload on` the `<html>` element does not work.

@dannywillems : Is there a particular reason for not using `Eliom_client.onload` here? I stuck with `a_onload` just in case.