### PR TITLE
Correct time zone handling (taking into account DST)

### DIFF
--- a/src/os_date.eliom
+++ b/src/os_date.eliom
@@ -25,47 +25,59 @@
 
 *)
 
-(*VVV Warning: Many improvements could be done.
-  For example handling daylight saving times changes porperly,
-  etc.
-*)
-
-(** The timezone offset. Use the browser date API. *)
-let%client timezone_offset =
-  truncate (-. float ((new%js Js.date_now) ##getTimezoneOffset) /. 60.)
-
-(** Defines the timezone using CalendarLib *)
-let%client tz = CalendarLib.Time_Zone.UTC_Plus timezone_offset
-
-(** Returns the user timezone *)
-let%client user_tz () = tz
+let%client timezone =
+  (* Use Intl API if available. Revert to using the time zone offset
+     otherwise. *)
+  match
+    if
+      Js.Opt.test Js.Unsafe.global##.Intl &&
+      Js.Opt.test Js.Unsafe.global##.Intl##.DateTimeFormat
+    then begin
+      let f = Js.Unsafe.global##.Intl##DateTimeFormat in
+      if Js.Opt.test f##.resolvedOptions then begin
+        let o = f##resolvedOptions in
+        Js.Opt.to_option o##.timeZone
+      end else
+        None
+    end else
+      None
+  with
+  | Some tz -> Js.to_string tz
+  | None    -> Printf.sprintf "Etc/GMT%+d"
+                 ((new%js Js.date_now)##getTimezoneOffset / 60)
 
 let user_tz_sr =
   Eliom_reference.Volatile.eref
     ~scope:Os_session.user_indep_session_scope
-    CalendarLib.Time_Zone.UTC
+    None
 
 let user_tz_gr =
   Eliom_reference.Volatile.eref
     ~scope:Eliom_common.default_group_scope
-    CalendarLib.Time_Zone.UTC
+    None
 (* We use 2 scopes in order to have the timezone set asap:
    - if user connected, we use last tz set by user
    - if not connected but new tab, we use same scope as other tabs
 *)
 
-let user_tz () =
+let user_tz_opt () =
   (* We take by default the timezone of the browser (session), if already set *)
   let tz = Eliom_reference.Volatile.get user_tz_sr in
-  if tz = CalendarLib.Time_Zone.UTC (* not set *)
+  if tz = None (* not set *)
   then Eliom_reference.Volatile.get user_tz_gr
   else tz
 
+let user_tz () =
+  match user_tz_opt () with
+  | None   -> "UTC"
+  | Some v -> v
+
+let%client user_tz () = timezone
 
 (* This function is called once by each client process to record on server
    the time zone of the client *)
 let init_client_process_time tz =
-  let tz = CalendarLib.Time_Zone.UTC_Plus tz in
+  let tz = Some tz in
   let () = Eliom_reference.Volatile.set user_tz_gr tz in
   let () = Eliom_reference.Volatile.set user_tz_sr tz in
   Lwt.return_unit
@@ -76,7 +88,8 @@ let%client init_time_rpc' = ()
 
 (** When the browser is loaded, we init the timezone *)
 let init_time_rpc : (_, unit) Eliom_client.server_function =
-  Eliom_client.server_function ~name:"os_date.init_time_rpc" [%derive.json: int]
+  Eliom_client.server_function ~name:"os_date.init_time_rpc"
+    [%derive.json: string]
     init_time_rpc'
 
 let%client init_time_rpc = ~%init_time_rpc
@@ -84,7 +97,7 @@ let%client init_time_rpc = ~%init_time_rpc
 let%client _ =
   (* We wait for the client process to be fully loaded: *)
   Eliom_client.onload (fun () ->
-    Lwt.async (fun () -> init_time_rpc timezone_offset))
+    Lwt.async (fun () -> init_time_rpc timezone))
 
 
 [%%shared
@@ -93,13 +106,66 @@ let%client _ =
   type local_calendar = CalendarLib.Calendar.t
 ]
 
-let%shared to_local date =
-  let user_tz = user_tz () in
-  CalendarLib.(Time_Zone.on Calendar.from_gmt user_tz date)
+(* Same as Unix.mktime when TZ=UTC, but avoid modifying this variable. *)
+let timegm =
+  let days =
+    [|0; 31; 59; 90; 120; 151; 181; 212; 243; 273; 304; 334|] in
+  fun {Unix.tm_year; tm_mon; tm_mday = mday; tm_hour = hour;
+       tm_min = min; tm_sec = sec} ->
+    let year = tm_year + 1900 in
+    let mon = tm_mon + 1 in
+    let r = (year - 1970) * 365 + days.(mon - 1) in
+    let r = r + (year - 1968) / 4 in
+    let r = r - (year - 1900) / 100 in
+    let r = r + (year - 1600) / 400 in
+    let r =
+      if mon <= 2 &&
+         (year mod 4 = 0) && (year mod 100 <> 0 || year mod 400 = 0)
+      then r - 1 else r in
+    let r = float (r + mday - 1) in
+    let r = 24. *. r +. float hour in
+    let r = 60. *. r +. float min in
+    60. *. r +. float sec
 
-let%shared to_utc date =
-  let user_tz = user_tz () in
-  CalendarLib.(Time_Zone.on Calendar.to_gmt user_tz date)
+let set_timezone =
+  let current_timezone = ref None in
+  fun tz ->
+  match !current_timezone with
+  | Some tz' when tz = tz' ->
+    ()
+  | _ ->
+    Unix.putenv "TZ" tz; (* Leaks memory... *)
+    current_timezone := Some tz
+
+(* To avoid one second errors, we round to the nearest second.
+   (The time can be slightly off and [Unix.localtime] round downwards...) *)
+let to_unixfloat d = floor (CalendarLib.Calendar.to_unixfloat d +. 0.5)
+
+let to_local ?(timezone = user_tz ()) d =
+  set_timezone timezone;
+  d |> to_unixfloat |> Unix.localtime
+    |> timegm |> CalendarLib.Calendar.from_unixfloat
+
+let to_utc ?(timezone = user_tz ()) d =
+  set_timezone timezone;
+  d |> to_unixfloat |> Unix.gmtime
+    |> Unix.mktime |> fst |> CalendarLib.Calendar.from_unixfloat
+
+let%client to_local d =
+  let d = CalendarLib.Calendar.to_unixfloat d in
+  let o = (new%js Js.date_fromTimeValue (d *. 1000.))##getTimezoneOffset in
+  CalendarLib.Calendar.from_unixfloat (d -. float o *. 60.)
+
+let%client to_utc d =
+  let d = CalendarLib.Calendar.to_unixfloat d in
+  let o = (new%js Js.date_fromTimeValue (d *. 1000.))##getTimezoneOffset in
+  let d' = d +. float o *. 60. in
+  let o' = (new%js Js.date_fromTimeValue (d' *. 1000.))##getTimezoneOffset in
+  CalendarLib.Calendar.from_unixfloat
+    (if o = o' then
+       d' (* We guessed the DST status right *)
+     else
+       d +. float o' *. 60.) (* Assume other DST status *)
 
 let%shared now () = to_local (CalendarLib.Calendar.now ())
 
@@ -134,7 +200,8 @@ let%shared smart_hours_minutes local_date =
 let%shared smart_hours_minutes_fixed local_date =
   Printer.Calendar.sprint "%I:%M%P" local_date
 
-let%shared unknown_timezone () = user_tz () = CalendarLib.Time_Zone.UTC
+let%server unknown_timezone () = user_tz_opt () = None
+let%client unknown_timezone () = false
 
 let%shared smart_hours_minutes date =
   if unknown_timezone () then

--- a/src/os_date.eliomi
+++ b/src/os_date.eliomi
@@ -36,17 +36,31 @@
 (** Type representing a local calendar. *)
 type local_calendar
 
+[%%server.start]
+
+(** Convert a local calendar to a UTC calendar. Use the client's
+    timezone unless the optional [timezone] argument is provided. *)
+val to_utc : ?timezone:string -> local_calendar -> CalendarLib.Calendar.t
+
+(** Convert any type of calendar to a local calendar. Use the client's
+    timezone unless the optional [timezone] argument is provided.*)
+val to_local : ?timezone:string -> CalendarLib.Calendar.t -> local_calendar
+
+[%%client.start]
+
 (** Convert a local calendar to a UTC calendar *)
 val to_utc : local_calendar -> CalendarLib.Calendar.t
 
 (** Convert any type of calendar to a local calendar. *)
 val to_local : CalendarLib.Calendar.t -> local_calendar
 
+[%%shared.start]
+
 (** [now ()] returns the current date as a [local_calendar] value. *)
 val now : unit -> local_calendar
 
 (** [user_tz ()] returns current user's timezone. *)
-val user_tz : unit -> CalendarLib.Time_Zone.t
+val user_tz : unit -> string
 
 (** Convert a [local_calendar] value to a [CalendarLib.Time.t] value. *)
 val to_local_time : local_calendar -> CalendarLib.Time.t


### PR DESCRIPTION
It leaks memory as it uses `putenv` when switching to a different time zone. To fix that, we should push for adding `setenv` to the OCaml Unix library or provide our own binding.

The API is slightly changed: `user_tz` now returns the time zone as a string rather than as an integer offset (which was wrong anyway, as some countries, such as India, uses time offsets which are not an integral number of hours).