### PR TITLE
update version of resource-pooling dependency

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -17,7 +17,7 @@ depends: [
   "ocsigen-toolkit" {>= "1.1"}
   "js_of_ocaml-camlp4"
   "yojson"
-  "resource-pooling"
+  "resource-pooling" {>= "0.3.1"}
 ]
 depexts: [
   [["debian"] ["imagemagick"]]


### PR DESCRIPTION
This ensures compatibility with Lwt 4.
I'm not sure whether this is actually necessary. I'll put my trust in the reviewer.