### PR TITLE
Os_session.on_start_(un(connected))_process: natural execution order

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigen-start"
-version: "1.8.0"
+version: "2.0.0"
 authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
 synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"

--- a/src/os_comet.eliom
+++ b/src/os_comet.eliom
@@ -114,7 +114,7 @@ let%client handle_message = function
 
 let _ =
   Os_session.on_start_process
-    (fun () ->
+    (fun _ ->
        let channel = create_monitor_channel () in
        Eliom_reference.Volatile.set monitor_channel_ref (Some channel);
        ignore [%client ( Lwt.async (fun () ->

--- a/src/os_current_user.eliom
+++ b/src/os_current_user.eliom
@@ -129,7 +129,7 @@ let%server () =
     unset_user_client (); (*VVV!!! will affect only current tab!! *)
     unset_user_server (); (* ok this is a request reference *)
     Lwt.return_unit);
-  Os_session.on_start_process (fun () ->
+  Os_session.on_start_process (fun _ ->
     Lwt_log.ign_debug ~section "start process action";
     Lwt.return_unit);
   Os_session.on_open_session (fun _ ->

--- a/src/os_notif.eliom
+++ b/src/os_notif.eliom
@@ -78,7 +78,7 @@ module Make(A : ARG) : S
     notify ?notfor key notif
 
   let _ =
-    Os_session.on_start_process init;
+    Os_session.on_start_process (fun _ -> init ());
     Os_session.on_post_close_session (fun () -> deinit () ; Lwt.return_unit)
 
 end

--- a/src/os_session.eliomi
+++ b/src/os_session.eliomi
@@ -24,7 +24,7 @@
 
 (** Call this to add an action to be done on server side
     when the process starts *)
-val on_start_process : (unit -> unit Lwt.t) -> unit
+val on_start_process : (Os_types.User.id option -> unit Lwt.t) -> unit
 
 (** Call this to add an action to be done
     when the process starts in connected mode, or when the user logs in *)


### PR DESCRIPTION
Until now the execution order of the handlers was:
1. everything registered using on_start_unconnected
2. everything registered using connected
3. everything registered using on_start_process

Now the execution order of all the handlers in these three sets is
according to the order of the registration. This ensures that handlers
registered by ocsigen-start are executed before the handlers of the
client application.