### PR TITLE
Mobile app: make sure there is a single initial request

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigen-start"
-version: "2.13.0"
+version: "2.14.0"
 authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
 synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"

--- a/src/os_date.eliomi
+++ b/src/os_date.eliomi
@@ -51,6 +51,10 @@ val to_local : ?timezone:string -> CalendarLib.Calendar.t -> local_calendar
     provided.  *)
 val now : ?timezone:string -> unit -> local_calendar
 
+(** You can use [initialize timezone] to communicate the client's
+   timezone to the client when the auto-initialization is disabled *)
+val initialize : string -> unit
+
 [%%client.start]
 
 (** Convert a local calendar to a UTC calendar *)
@@ -61,6 +65,9 @@ val to_local : CalendarLib.Calendar.t -> local_calendar
 
 (** [now ()] returns the current date as a [local_calendar] value. *)
 val now : unit -> local_calendar
+
+(** Disable auto-initialization *)
+val disable_auto_init : unit -> unit
 
 [%%shared.start]
 

--- a/template.distillery/PROJECT_NAME_mobile.eliom
+++ b/template.distillery/PROJECT_NAME_mobile.eliom
@@ -14,10 +14,11 @@ open%client Js_of_ocaml_lwt
    app) early on and subsequent requests from the client will contain
    the proper cookies.
 
-   The RPC is empty by default, but you can add your own actions to be
-   performed server side on first client request, if necessary. *)
-let%server init_request _myid_o () =
-  Lwt.return_unit
+   The RPC only initializes Os_date by default, but you can add your
+   own actions to be performed server side on first client request, if
+   necessary. *)
+let%server init_request _myid_o tz =
+  Os_date.initialize tz; Lwt.return_unit
 
 let%server init_request_rpc : (_, unit) Eliom_client.server_function =
   Eliom_client.server_function ~name:"%%%MODULE_NAME%%%_mobile.init_request"
@@ -62,12 +63,13 @@ let handle_initial_url () =
 
 let () =
   Lwt.async @@ fun () ->
-  if Eliom_client.is_client_app () then
+  if Eliom_client.is_client_app () then begin
     (* Initialize the application server-side; there should be a
        single initial request for that. *)
+    Os_date.disable_auto_init ();
     let%lwt _ = Lwt_js_events.onload () in
     handle_initial_url ()
-  else
+  end else
     Lwt.return_unit
 
 (* Reactivate comet on resume and online events *)


### PR DESCRIPTION
For that, we disable the automatic initialization of `Os_date`, which is initialized instead through this request.