### PR TITLE
[template][mobile][config] Allow cleartext on dev builds

### DIFF
--- a/template.distillery/Makefile.local.example
+++ b/template.distillery/Makefile.local.example
@@ -12,3 +12,7 @@ APP_SERVER       := http://YOUR_IP_ADDRESS:PORT
 # while building the mobile application.
 # See Makefile.mobile for more information about this variable.
 APP_REMOTE       := yes
+
+# Use to declare the app as a dev build that should access cleartext data
+# over `http`. A release should be anything else than `dev`.
+APP := dev

--- a/template.distillery/Makefile.mobile
+++ b/template.distillery/Makefile.mobile
@@ -188,6 +188,12 @@ else
 APP_PORT_ARG=
 endif
 
+ifeq ($(APP),dev)
+  MOBILE_USE_CLEARTEXT_TRAFFIC?=<edit-config file=\"app/src/main/AndroidManifest.xml\" mode=\"merge\" target=\"/manifest/application\"><application android:usesCleartextTraffic=\"true\"/></edit-config>
+else
+  MOBILE_USE_CLEARTEXT_TRAFFIC?=
+endif
+
 # This rule generates the config.xml file from mobile/config.xml.in.
 $(CORDOVAPATH)/config.xml: mobile/config.xml.in $(CORDOVAPATH)
 	sed -e "s,%%APPSERVER%%,$(APP_SERVER),g" \
@@ -204,6 +210,7 @@ $(CORDOVAPATH)/config.xml: mobile/config.xml.in $(CORDOVAPATH)
 	    -e "s,%%MOBILE_AUTHOR_DESCRIPTION%%,$(MOBILE_AUTHOR_DESCRIPTION),g" \
 	    -e "s,%%MOBILE_ANDROID_SDK_VERSION%%,$(MOBILE_ANDROID_SDK_VERSION),g" \
 	    -e "s,%%MOBILE_NOTIFICATIONS_SENDER_ID%%,$(MOBILE_NOTIFICATIONS_SENDER_ID),g" \
+        -e "s,%%MOBILE_USE_CLEARTEXT_TRAFFIC%%,$(MOBILE_USE_CLEARTEXT_TRAFFIC),g" \
 	    mobile/config.xml.in > $@
 
 # This rule generates index.html. md5sum is used to set the right JavaScript

--- a/template.distillery/README.md
+++ b/template.distillery/README.md
@@ -233,7 +233,7 @@ commands if you want to test on your local machine.
 - To run the application in the emulator, use:
 
 ```
-make APP_SERVER=http://${YOUR_SERVER} APP_REMOTE=no emulate-android
+make APP_SERVER=http://${YOUR_SERVER} APP_REMOTE=no APP=dev emulate-android
 ```
 
 The above command will attempt to launch your app in the Android emulator that
@@ -249,7 +249,7 @@ details).
 To run the application on a connected device, use:
 
 ```
-make APP_SERVER=http://${YOUR_SERVER} APP_REMOTE=no run-android
+make APP_SERVER=http://${YOUR_SERVER} APP_REMOTE=no APP=dev run-android
 ```
 Notice that the `APP_SERVER` argument needs to point to your LAN or public
 address (e.g., `192.168.1.x`), not to `127.0.0.1` (neither to `localhost`). The
@@ -258,7 +258,7 @@ which `127.0.0.1` has different meaning; it points to the Android host itself.
 
 If you only want to build the mobile application, you can use:
 ```
-make APP_SERVER=http://${YOUR_SERVER} APP_REMOTE=no android
+make APP_SERVER=http://${YOUR_SERVER} APP_REMOTE=no APP=dev android
 ```
 
 Before uploading on Google Play Store, check the variables in Makefile.options
@@ -299,12 +299,14 @@ make APP_SERVER=http://${YOUR_SERVER} APP_REMOTE={yes|no} chcp
 ## Use Makefile.local file.
 
 You need to define `APP_REMOTE` and `APP_SERVER` each time you want to build
-the mobile application or to update it.
+the mobile application or to update it. The `APP` variable is not mandatory per
+say but when set to `dev` it enables cleartext traffic, so you might want to
+keep it on while working on dev builds.
 
-If you don't want to pass the variables `APP_SERVER` and
+If you don't want to pass the variables `App`, `APP_SERVER` and
 `APP_REMOTE` every time, you can change the values of these variables in
 `Makefile.local.example` and rename this file to `Makefile.local`. This way,
-the variables `APP_REMOTE` and `APP_SERVER` are not mandatory when you build
+the variables `App`, `APP_REMOTE` and `APP_SERVER` are not mandatory when you build
 or update the mobile application. You can use:
 ```
 make chcp

--- a/template.distillery/mobile!config.xml.in
+++ b/template.distillery/mobile!config.xml.in
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="%%APPID%%" version="%%MOBILE_APP_VERSION%%" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="%%APPID%%" version="%%MOBILE_APP_VERSION%%" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+    %%MOBILE_USE_CLEARTEXT_TRAFFIC%%
     <name>%%MOBILE_APP_NAME%%</name>
     <description>
       %%MOBILE_DESCRIPTION%%


### PR DESCRIPTION
Update the template's mobile build and config to allow cleartext on dev builds.