### PR TITLE
Os_db: connection wrapper

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigen-start"
-version: "2.16.2"
+version: "2.17.0"
 authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
 synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"

--- a/src/os_core_db.mli
+++ b/src/os_core_db.mli
@@ -40,7 +40,6 @@ val init :
   unit ->
   unit
 
-
 (** [full_transaction_block f] executes function [f] within a database
     transaction. The argument of [f] is a PGOCaml database handle. *)
 val full_transaction_block :
@@ -53,3 +52,10 @@ val without_transaction :
 
 (** Direct access to the connection pool *)
 val connection_pool : unit -> PGOCaml.pa_pg_data PGOCaml.t Resource_pool.t
+
+(** Setup a wrapper function which is used each time a connection is
+   acquired. This function can perform some actions before and/or
+   after the connection is used. *)
+type wrapper =
+  { f : 'a. PGOCaml.pa_pg_data PGOCaml.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t }
+val set_connection_wrapper : wrapper -> unit


### PR DESCRIPTION
Add the possibility to setup a wrapper function which is used each time a connection is acquired. This function can perform some actions before and/or after the connection is used