### PR TITLE
fix pkg set to js_of_ocaml-ppx_deriving_json #589

### DIFF
--- a/Makefile.options
+++ b/Makefile.options
@@ -54,7 +54,7 @@ SASS_TEMPORARY_PROJECT_NAME := os_temporary_project_name
 ##----------------------------------------------------------------------
 
 # OCamlfind packages for the server
-SERVER_PACKAGES    := lwt_ppx js_of_ocaml-ppx.deriving calendar safepass \
+SERVER_PACKAGES    := lwt_ppx js_of_ocaml-ppx_deriving_json calendar safepass \
                       ocsigen-toolkit.server yojson re.str cohttp-lwt-unix \
                       netstring
 
@@ -62,7 +62,7 @@ SERVER_DB_PACKAGES := lwt_ppx pgocaml pgocaml_ppx \
                       calendar safepass resource-pooling
 
 # OCamlfind packages for the client
-CLIENT_PACKAGES    := lwt_ppx js_of_ocaml-ppx.deriving js_of_ocaml-ppx \
+CLIENT_PACKAGES    := lwt_ppx js_of_ocaml-ppx_deriving_json js_of_ocaml-ppx \
                       calendar ocsigen-toolkit.client re.str
 
 # Debug package (yes/no): Debugging info in compilation

--- a/template.distillery/Makefile.options
+++ b/template.distillery/Makefile.options
@@ -24,13 +24,13 @@ CLIENT_FILES          := $(wildcard *.eliomi *.eliom) \
 SERVER_ELIOM_PACKAGES := ocsigen-start.server
 
 # OCamlfind packages for the server
-SERVER_PACKAGES       := lwt_ppx js_of_ocaml-ppx.deriving ppx_deriving.std pgocaml
+SERVER_PACKAGES       := lwt_ppx js_of_ocaml-ppx_deriving_json ppx_deriving.std pgocaml
 
 # OCamlfind packages for database access
 SERVER_DB_PACKAGES    := pgocaml pgocaml_ppx
 
 # OCamlfind packages for the client
-CLIENT_PACKAGES       := lwt_ppx js_of_ocaml-ppx js_of_ocaml-ppx.deriving \
+CLIENT_PACKAGES       := lwt_ppx js_of_ocaml-ppx js_of_ocaml-ppx_deriving_json \
                          ppx_deriving.std ocsigen-start.client base
 
 # Automatically install packages via NPM


### PR DESCRIPTION
See [ocsigen-start doesn't compile after js_of_ocaml.3.6.0 update ](https://github.com/ocsigen/ocsigen-start/issues/589).
