### PR TITLE
Os_tips: Change the type of 'onclose'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+===== 4.0.0 (2021-01-13) =====
+* BREAKING CHANGE Os_tips: change the type of 'onclose'
+
 ===== 2.13.0 (2019-12-20) =====
 * Os_tips: add unset_tip_seen
 

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigen-start"
-version: "3.0.0"
+version: "4.0.0"
 authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
 synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"

--- a/src/os_tips.eliomi
+++ b/src/os_tips.eliomi
@@ -57,7 +57,7 @@ val bubble :
   ?width:int Eliom_client_value.t ->
   ?parent_node:[< `Body | Html_types.body_content ] Eliom_content.Html.elt ->
   ?delay:float ->
-  ?onclose:(unit -> unit) Eliom_client_value.t ->
+  ?onclose:(unit -> unit Lwt.t) Eliom_client_value.t ->
   name:string ->
   content:((unit -> unit Lwt.t)
            -> Html_types.div_content Eliom_content.Html.elt list Lwt.t)
@@ -72,7 +72,7 @@ val bubble :
 val block :
   ?a:[< Html_types.div_attrib > `Class ] Eliom_content.Html.D.attrib list ->
   ?recipient:[> `All | `Connected | `Not_connected ] ->
-  ?onclose:(unit -> unit) Eliom_client_value.t ->
+  ?onclose:(unit -> unit Lwt.t) Eliom_client_value.t ->
   name:string ->
   content:((unit -> unit Lwt.t) Eliom_client_value.t
            -> Html_types.div_content Eliom_content.Html.elt list Lwt.t) ->


### PR DESCRIPTION
I need to animate with `Lwt` the closing of a tip
