### PR TITLE
Add option <usedefaulthostname/> in template config file

### DIFF
--- a/template.distillery/PROJECT_NAME.conf.in
+++ b/template.distillery/PROJECT_NAME.conf.in
@@ -11,6 +11,7 @@
     <datadir>%%DATADIR%%</datadir>
     <charset>utf-8</charset>
     <uploaddir>/tmp</uploaddir> <!-- Customize this -->
+    <usedefaulthostname/>
     %%% Only set when debugging
     %%DEBUGMODE%%
     <extension findlib-package="ocsigenserver.ext.accesscontrol"/>


### PR DESCRIPTION
It is mandatory behind a reverseproxy, and will probably always be what we want otherwise.
