### PR TITLE
[actions] fix ssl error during Github Actions compilation on macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,8 @@ jobs:
       - run: opam install -y .
         working-directory: template
 
-      - run: make db-init db-create db-schema
+      - run: make USE_SASS=no db-init db-create db-schema
         working-directory: template
 
-      - run: opam exec -- make all
+      - run: opam exec -- make USE_SASS=no all
         working-directory: template

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
 
       - run: opam pin add ocsigen-start.dev . --no-action
 
-      - run: opam depext ocsigen-start
-
-      - run: opam install . --deps-only
+      - name: Install OpenSSL on MacOS
+        run: brew install openssl@3
+        if: ${{ matrix.os == 'macos-latest' }}
 
       - run: opam install .
 


### PR DESCRIPTION
opam depext doesn't seem to have an effect on MacOS.
It only prints the packages one needs to install manually.