### PR TITLE
[cleanup] Avoid warnings 16 (`unerasable-optional-argument`)

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigen-start"
-version: "4.6.0"
+version: "5.0.0"
 authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
 synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"

--- a/src/os_uploader.eliomi
+++ b/src/os_uploader.eliomi
@@ -40,6 +40,7 @@ val resize_image
   -> ?dst:string
   -> width:int
   -> height:int
+  -> unit
   -> unit Lwt.t
 (** Resize the given image ([src]) and save it to [dst] (default is the source
    file). If an error occurred, it raises the exception [Error_while_resizing]
@@ -54,6 +55,7 @@ val crop_image
   -> right:float
   -> bottom:float
   -> left:float
+  -> unit
   -> unit Lwt.t
 (** [crop_image ~src ?dst ?ratio ~top ~right ~bottom ~left] crops the image
     saved in [src] and saves the result in [dst] (default is the source file).


### PR DESCRIPTION
It involves changing the major version.
