### PR TITLE
[sessions] Adjust server-side interface of `Os_session.disconnect_all`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+===== 6.1.0 (2022-03-08) =====
+* Adjust the server-side interface of Os_session.disconnect_all
+
 ===== 4.0.0 (2021-01-13) =====
 * BREAKING CHANGE Os_tips: change the type of 'onclose'
 

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigen-start"
-version: "6.0.1"
+version: "6.1.0"
 authors: "dev@ocsigen.org"
 maintainer: "dev@ocsigen.org"
 synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"

--- a/opam
+++ b/opam
@@ -23,7 +23,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "4.0.0"}
-  "eliom" {>= "9.3.0" & < "10.0.0"}
+  "eliom" {>= "10.0.0" & < "11.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-ppx-rpc"
   "ocsigen-i18n" {>= "3.7.0"}

--- a/src/os_session.eliom
+++ b/src/os_session.eliom
@@ -120,7 +120,7 @@ let set_warn_connection_change, warn_connection_changed =
   let r = ref (fun _ -> ()) in
   (fun f -> r := f), fun state -> !r state; Lwt.return_unit
 
-let disconnect_all ?userid ?(user_indep = true) () =
+let disconnect_all ?userid ?(user_indep = true) ?(with_restart = true) () =
   let close_my_sessions = userid = None in
   let%lwt () =
     if close_my_sessions then pre_close_session_action () else Lwt.return_unit
@@ -199,7 +199,9 @@ let disconnect_all ?userid ?(user_indep = true) () =
             ui_states
         else Lwt.return_unit
       in
-      let _ = [%client (Os_handlers.restart () : unit)] in
+      let () =
+        if with_restart then ignore [%client (Os_handlers.restart () : unit)]
+      in
       Lwt.return_unit
 
 let check_allow_deny userid allow deny =

--- a/src/os_session.eliomi
+++ b/src/os_session.eliomi
@@ -88,11 +88,14 @@ val connect : ?expire:bool -> Os_types.User.id -> unit Lwt.t
 val disconnect_all
   :  ?userid:Os_types.User.id
   -> ?user_indep:bool
+  -> ?with_restart:bool
   -> unit
   -> unit Lwt.t
 (** Close all sessions of current user (or [userid] if present).
     If [?user_indep] is [true]
     (default), will also affect [user_indep_session_scope].
+    If [?with_restart] is [true]
+    (default), will also restart the client.
 *)
 
 [%%client.start]

--- a/src/os_session.eliomi
+++ b/src/os_session.eliomi
@@ -86,7 +86,8 @@ val connect : ?expire:bool -> Os_types.User.id -> unit Lwt.t
 *)
 
 val disconnect_all
-  :  ?userid:Os_types.User.id
+  :  ?sitedata:Eliom_common.sitedata
+  -> ?userid:Os_types.User.id
   -> ?user_indep:bool
   -> ?with_restart:bool
   -> unit
@@ -96,6 +97,14 @@ val disconnect_all
     (default), will also affect [user_indep_session_scope].
     If [?with_restart] is [true]
     (default), will also restart the client.
+    If you do not call the function during
+    a request or during the initialisation phase of the Eliom module:
+
+    - [?userid] must not be [None]
+    - [?with_restart] must be [false]
+    - you must provide the extra parameter [?sitedata],
+      that you can get by calling [Eliom_request_info.get_sitedata]
+      during the initialisation phase of the Eliom module.
 *)
 
 [%%client.start]

--- a/template.distillery/PROJECT_NAME.opam
+++ b/template.distillery/PROJECT_NAME.opam
@@ -4,7 +4,7 @@ version: "0.1"
 synopsis: "Pseudo package for defining project dependencies"
 
 depends: [
-  "eliom" {>= "9.3.0" & < "10.0.0"}
+  "eliom" {>= "10.0.0" & < "11.0.0"}
   "ocsipersist-pgsql" {>= "1.0" & < "2.0"}
   "ocsigen-start"
 ]


### PR DESCRIPTION
So that it is possible to call `Os_session.disconnect_all` outside
a request or the initialization phase of the Eliom module (see
https://ocsigen.org/eliom/dev/api/server/Eliom_state.Ext#VALfold_volatile_sub_states).

~~Depends on https://github.com/ocsigen/eliom/pull/745, waiting for the opam release of Eliom 10.0.0.~~
