### PR TITLE
[opam] Fix the constraint on the OCaml version

### DIFF
--- a/opam
+++ b/opam
@@ -18,7 +18,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 depends: [
-  "ocaml" {>= "4.06.1"}
+  "ocaml" {>= "4.08.1"}
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}


### PR DESCRIPTION
Ocsigen Start depends indirectly on Ocsigenserver 5 which needs OCaml at
least 4.08.1.
