### PR TITLE
[template] Use `opam var` instead of `opam config var`

### DIFF
--- a/template.distillery/Makefile.db
+++ b/template.distillery/Makefile.db
@@ -24,7 +24,7 @@ export PGPASSWORD := $(DB_PASSWORD)
 OCSIGENSERVER     := $(OCSIGENSERVER)
 OCSIGENSERVER.OPT := $(OCSIGENSERVER.OPT)
 
-OPAM_LIB_DIR      := $(shell opam config var lib)
+OPAM_LIB_DIR      := $(shell opam var lib)
 OS_UPGRADE_FILE   := $(OPAM_LIB_DIR)/eliom/templates/os.pgocaml/upgrade.sql
 ## ---------------------------------------------------------------------
 

--- a/template.distillery/Makefile.options
+++ b/template.distillery/Makefile.options
@@ -122,7 +122,7 @@ LOCAL_STATIC_DEFAULTCSS      := $(LOCAL_STATIC)/defaultcss
 LOCAL_CSS             := $(LOCAL_STATIC_DEFAULTCSS)/$(PROJECT_NAME).css
 
 # The OPAM share directory.
-SHAREDIR              := $(shell $(OPAM) config var share)
+SHAREDIR              := $(shell $(OPAM) var share)
 
 # The ocsigen-toolkit directory containing CSS files.
 SHAREDIR_OT_CSS       := $(SHAREDIR)/ocsigen-toolkit/css


### PR DESCRIPTION
To avoid warnings about the use of the deprecated command `opam config var` in opam 2.1.
