### PR TITLE
[ci] Use the latest version of `actions/checkout`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2


### PR DESCRIPTION
To avoid the warning about deprecated Node.js 12 actions.  See https://github.com/ocsigen/ocsigen-start/actions/runs/4716635327.
