### PR TITLE
doc: odoc/wodoc migration — manual + API refs (dev / 9.0.0)

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -41,8 +41,8 @@ jobs:
           # being built so odoc_driver documents these sources.
           opam install . --deps-only --with-doc
           opam install . --with-doc
-          # odoc-driver with the base_args fix (cross-library links). TODO: switch
-          # to the upstream release once the fix lands; until then pin the fork.
+          # odoc-driver with the cross-library link fix (driver: link units only
+          # against their actual lib deps). TODO: drop the pin once it lands upstream.
           opam pin add -n odoc https://github.com/ocsigen/odoc.git#base-args
           opam pin add -n odoc-driver https://github.com/ocsigen/odoc.git#base-args
           opam install odoc odoc-driver

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -43,8 +43,8 @@ jobs:
           opam install . --with-doc
           # odoc-driver with the cross-library link fix (driver: link units only
           # against their actual lib deps). TODO: drop the pin once it lands upstream.
-          opam pin add -n odoc https://github.com/ocsigen/odoc.git#base-args
-          opam pin add -n odoc-driver https://github.com/ocsigen/odoc.git#base-args
+          opam pin add -n odoc https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
+          opam pin add -n odoc-driver https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
           opam install odoc odoc-driver
           # wodoc: the odoc driver that themes the pages with the Ocsigen chrome.
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,11 +16,16 @@ name: Documentation
 on:
   push:
     branches: [master]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Publish a stable version: freeze the dev docs now on gh-pages as /<version>/ and repoint `latest` (e.g. 1.2.3). Leave empty to just rebuild dev."
+        required: false
+        default: ""
 
 jobs:
   build-deploy:
-    if: github.repository == 'ocsigen/ocsigen-start'
+    if: github.repository == 'ocsigen/ocsigen-start' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version == '')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -72,3 +77,46 @@ jobs:
           folder: _doc-site/dev
           target-folder: dev
           clean: true
+
+  release:
+    # Manual run with a version: freeze the dev docs currently on gh-pages as the
+    # stable /<version>/ and repoint `latest` at it (refreshing versions.json).
+    # No rebuild -- the docs of a release are exactly the dev docs at that point.
+    if: github.repository == 'ocsigen/ocsigen-start' && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install wodoc
+        run: |
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: site
+          fetch-depth: 0
+
+      - name: Freeze dev as the stable version and repoint latest
+        # wodoc release: cp -a site/dev site/<version>, ln -sfn <version> latest,
+        # write the root index.html redirect if missing, refresh versions.json.
+        run: >-
+          opam exec -- wodoc release --site site --from dev
+          --version "${{ github.event.inputs.version }}"
+
+      - name: Commit and push gh-pages
+        run: |
+          cd site
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet \
+            || git commit -m "Release doc ${{ github.event.inputs.version }} (freeze dev, repoint latest)"
+          git push

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -55,12 +55,6 @@ jobs:
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
           opam install wodoc
 
-      - name: Overlay the manual menu (lives on the wikidoc branch)
-        run: |
-          git fetch origin wikidoc
-          mkdir -p doc/manual
-          git show origin/wikidoc:doc/dev/manual/menu.wiki > doc/manual/menu.wiki
-
       - name: Build documentation (dev)
         # wodoc build runs `odoc_driver ocsigen-start --remap` on the installed package
         # (after preprocessing the installed manual .mld), assembles the themed

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,74 @@
+# Build the Ocsigen Start documentation (manual + server/client API) with odoc_driver,
+# theme it with the Ocsigen chrome (wodoc), and publish it on the project's
+# gh-pages branch, served at https://ocsigen.org/ocsigen-start/. See doc/README.md.
+#
+# CI deploys ONLY the "dev" docs and ONLY from master. Stable versions are built
+# by hand and committed to gh-pages at release time, so there is no dispatch /
+# release path here. Each run replaces only the dev/ directory; the other version
+# directories already on gh-pages are PRESERVED.
+#
+# PREREQUISITE: wodoc builds the API with `odoc_driver ocsigen-start --remap` on the
+# INSTALLED ocsigen-start, and its cross-library links need the odoc_driver `base_args`
+# fix, which is not yet upstreamed. Until it lands, the "Install dependencies" step
+# must pin odoc / odoc-driver from the patched source (see below).
+name: Documentation
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+  build-deploy:
+    if: github.repository == 'ocsigen/ocsigen-start'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install dependencies
+        run: |
+          # The documented version is the INSTALLED eliom: install it from the ref
+          # being built so odoc_driver documents these sources.
+          opam install . --deps-only --with-doc
+          opam install . --with-doc
+          # odoc-driver with the base_args fix (cross-library links). TODO: switch
+          # to the upstream release once the fix lands; until then pin the fork.
+          opam pin add -n odoc https://github.com/ocsigen/odoc.git#base-args
+          opam pin add -n odoc-driver https://github.com/ocsigen/odoc.git#base-args
+          opam install odoc odoc-driver
+          # wodoc: the odoc driver that themes the pages with the Ocsigen chrome.
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Overlay the manual menu (lives on the wikidoc branch)
+        run: |
+          git fetch origin wikidoc
+          mkdir -p doc/manual
+          git show origin/wikidoc:doc/dev/manual/menu.wiki > doc/manual/menu.wiki
+
+      - name: Build documentation (dev)
+        # wodoc build runs `odoc_driver ocsigen-start --remap` on the installed package
+        # (after preprocessing the installed manual .mld), assembles the themed
+        # site from doc/wodoc, and fetches the shared menu from ocsigen.github.io.
+        run: >-
+          opam exec -- wodoc build --config doc/wodoc
+          --menu https://ocsigen.org/wodoc/menu.html
+          --out "$PWD/_doc-site/dev" --label dev
+
+      - name: Deploy to gh-pages (replace only dev/, keep the rest)
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: _doc-site/dev
+          target-folder: dev
+          clean: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ local/
 doc/client
 doc/server
 .*.sw*
+doc/manual/menu.wiki

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,50 @@
+# How the Ocsigen Start documentation is generated
+
+The Ocsigen Start documentation published at <https://ocsigen.org/ocsigen-start/>
+is built with **odoc** and themed with the Ocsigen site chrome by
+[**wodoc**](https://github.com/ocsigen/wodoc) (an odoc driver).
+
+Ocsigen Start is a **client/server** project: it ships its server and client APIs
+as two libraries of the same package (`ocsigen-start.server` /
+`ocsigen-start.client`) with the **same module names**, so `dune build @doc`
+collides. The API is therefore built with `odoc_driver ocsigen-start --remap` on
+the **installed** package — the documented version is whatever the build switch
+has installed.
+
+## Sources
+
+| What | Where | Format |
+|---|---|---|
+| Manual | the package's `(documentation)` `.mld` (built with the API) | odoc pages |
+| Manual nav order | `doc/manual/menu.wiki` (overlaid from the `wikidoc` branch by CI) | wiki menu |
+| Server / client API | `doc/server.indexdoc` / `doc/client.indexdoc` | odoc index |
+| Site configuration | [`doc/wodoc`](wodoc) | wodoc config (S-expression) |
+
+The whole site — per-side API navs, the client/server switch, the body colour,
+the shared manual nav and the relative cross-links into sibling Ocsigen projects
+— is declared in [`doc/wodoc`](wodoc) and produced by a single `wodoc build`.
+There is **no `build.sh`** and no Python.
+
+## Build
+
+```
+opam install . --with-doc        # the version to document (installed)
+opam install wodoc
+git show origin/wikidoc:doc/dev/manual/menu.wiki > doc/manual/menu.wiki
+wodoc build --config doc/wodoc --label dev --out _doc-site/dev \
+  --menu https://ocsigen.org/wodoc/menu.html
+```
+
+> **Prerequisite (CI).** The cross-library links need the `odoc_driver`
+> `base_args` fix, not yet upstreamed; CI must pin `odoc` / `odoc-driver` from the
+> patched source until it lands (see the workflow comments).
+
+## Deployment (CI)
+
+[`.github/workflows/doc.yml`](../.github/workflows/doc.yml) deploys to **`gh-pages`**
+(served at `ocsigen.org/ocsigen-start/`). The CI triggers **only on `master`**:
+
+- **push to `master`** → rebuilds and deploys the **`dev`** docs only.
+
+Stable versions are built by hand and committed to `gh-pages` (with `latest`
+repointed) at release time. Each CI run replaces only the `dev/` directory.

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,5 @@
+; Ocsigen Start manual pages (odoc .mld), compiled in place with the API by
+; `dune build @doc` and installed with the package, so they appear on ocaml.org
+; and resolve {{!page-X}} / {!Module} references against the API.
+(documentation
+ (package ocsigen-start))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,24 @@
+{0 Ocsigen Start}
+
+Ocsigen Start is a ready-to-use application skeleton for building
+client-server web and mobile applications with {{:../eliom}Eliom} and
+{{:../ocsigen-toolkit}Ocsigen Toolkit}. It ships with user management,
+notifications, a database schema and many code examples, so you can
+focus on your own features from day one.
+
+Ocsigen Start is part of the {{:https://ocsigen.org}Ocsigen project}.
+
+{1 Documentation}
+
+- {{!page-intro}Introduction} — installation, getting started and an
+  overview of the modules Ocsigen Start provides.
+- The server and client API of every module (use the {e Server API} /
+  {e Client API} switch to move between the two sides).
+
+{1 Installation}
+
+Ocsigen Start is available via OPAM:
+
+{[
+opam install ocsigen-start
+]}

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -1,0 +1,241 @@
+
+
+{0 Introduction}
+
+Ocsigen Start is an application template written with Eliom, Js_of_ocaml,
+Ocsigen Toolkit, etc.
+It contains many standard features like user management, notifications,
+and many code examples.
+
+Use it to learn Ocsigen or to quickly create your own Minimum Viable Product.
+It is probably the fastest way to get started with Ocsigen.
+
+The application is cross-platform: it works as a Web app or as a mobile app
+for iOS or Android (via {{:https://cordova.apache.org/}Cordova})..
+
+
+{1 Demo}
+
+If you want to test the demo application before installing Ocsigen Start,
+{b a live version is running {{:../ocsigen-start/demo/}here}}.
+
+You can also download the mobile app
+{{:https://play.google.com/store/apps/details?id=com.osdemo.mobile}on Google Play store} (for Android)
+or download the
+{{:files/osdemo.apk}APK for Android}
+or the
+{{:files/osdemo-ios.tgz}iOS version} (to be installed using XCode).
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start1.png}
+{{files/screenshots/start1.png|Ocsigen Start}}}
+{{:files/screenshots/start2.png}
+{{files/screenshots/start2.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start-mobile-1.png}
+{{files/screenshots/start-mobile-1.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-2.png}
+{{files/screenshots/start-mobile-2.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-4.png}
+{{files/screenshots/start-mobile-4.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+
+
+Ocsigen Start is composed by two main parts:
+
+- The generated code which gives a default behaviour to your application. Adapt it to your needs and remove the parts you don't need. Feel free to redistribute it as you wish.{%html:<br/>%}
+It includes a demo of many features from Eliom, Js_of_ocaml, Tyxml, Ocsigen Toolkit. Use it to learn quickly the main principles of multi-tier programming.
+
+- A library with:
+- User management: authentication, registration of new users with activation links sent by email, recover lost password, page to update settings, etc.
+- Tips for new users
+- Push notifications to send information to other users
+- ...
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start3.png}
+{{files/screenshots/start3.png|Ocsigen Start}}}
+{{:files/screenshots/start4.png}
+{{files/screenshots/start4.png|Ocsigen Start}}}
+{{:files/screenshots/start5.png}
+{{files/screenshots/start5.png|Ocsigen Start}}}
+{{:files/screenshots/start6.png}
+{{files/screenshots/start6.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start-mobile-3.png}
+{{files/screenshots/start-mobile-3.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-6.png}
+{{files/screenshots/start-mobile-6.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-7.png}
+{{files/screenshots/start-mobile-7.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-8.png}
+{{files/screenshots/start-mobile-8.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+
+{1 Getting started}
+
+Read {{:../tuto/start.html}this page} to learn how to build your first Ocsigen Start app in 5 minutes.
+
+{1 Implementation overview}
+
+{2 Template}
+
+The library portion of Ocsigen Start contains core functionality that
+is common across Ocsigen Start applications, while the template can be
+customized for the specific application at hand.
+
+The template additionally contains a demonstration of relevant
+{{:https://github.com/ocsigen/ocsigen-toolkit}Ocsigen Toolkit}
+widgets. The demo portion can easily be removed.
+
+{2 Database}
+
+For implementing users, a database is needed. Specifically, we use
+{{:https://www.postgresql.org/}PostgreSQL} via the
+{{:http://pgocaml.forge.ocamlcore.org/}PGOCaml} library. The template
+and the library make common assumptions about the database schema. The
+database thus needs to be instantiated in a certain way; this is
+automatically done by appropriate targets in the template's build
+system.
+
+The same database can used for the specific needs of the application
+at hand. For that, new tables can be added. The original ones should
+remain in place for Ocsigen Start to work correctly.
+
+{2 Internationalization (i18n)}
+
+The template is available in multiple languages (English and French) using
+{{:https://github.com/besport/ocsigen-i18n}ocsigen-i18n}. All translations used
+in the template are defined in the file [assets/PROJECT_NAME_i18n.tsv]. The
+Makefile rule [i18n-udpate] generates the i18n module. You need to use it
+every time the TSV file is updated.
+
+See [Makefile.i18n] for rules about i18n and [Makefile.options] to
+personalize the internalization of your application (for example add new
+languages, change default language, change TSV filename).
+
+{2 Managing e-mails}
+
+The template application keeps track of users' e-mails and implements
+e-mail validation. For that, [sendmail] (or another mail transfer
+agent compatible with it) needs to be installed on the host.
+
+{2 Style}
+
+The application provides a standard style matching contemporary
+aesthetics. For this, we use {{:http://sass-lang.com/}SASS}. The style
+can be customized by modifying the SASS files that are part of the
+template.
+
+{1 Installation}
+
+Ocsigen Start can be installed via
+{{:https://opam.ocaml.org/}OPAM}. The package name is [ocsigen-start].
+The template application can be instantiated via [eliom-distillery]:
+
+{@shell[
+eliom-distillery -name $APP_NAME -template os
+]}
+
+(Replace $APP_NAME by the name of your application).
+
+For details on launching the application, refer to the template's
+{{:https://github.com/ocsigen/ocsigen-start/blob/master/template.distillery/README.md}README}.
+
+{1 Library overview}
+
+We provide a tour of the Ocsigen Start library. All modules have
+server- and client-side versions. (In the API documentation, there are
+links near the top of each module page for selecting the side.)
+
+The template uses all these modules, and can thus act as a good
+starting guide. Look around!
+
+{2 User interface}
+
+Various modules for producing icons, messages, custom pages, tips,
+connection forms, etc.
+
+- {!Os.Icons}:
+  manage CSS icons.
+- {!Os.Msg}:
+  write messages in the browser console.
+- {!Os.Page}:
+  utilities for building HTML pages that follow the standard Ocsigen
+  Start layout.
+- {!Os.Tips}:
+  display tips to the user.
+- {!Os.User_view}:
+  functions for creating password forms and other common UI elements
+  appearing in applications and for managing the user connection box.
+- {!Os.Uploader}:
+  ImageMagick-based tools for manipulating avatars.
+
+{2 Users and groups}
+
+- {!Os.User},
+  {!Os.Current_user},
+  {!Os.Group}:
+  manage users and groups thereof.
+
+- {!Os.Db}:
+  directly access the database. In many cases, it is a better idea to
+  use higher-level modules (e.g.,
+  {!Os.User}).
+
+- {!Os.Types}:
+  core types shared by {!Os.Db}
+  and the higher-level modules.
+
+{2 Communication}
+
+- {!Os.Notif}:
+  send notifications to connected users.
+
+- {!Os.Email}:
+  send e-mails.
+
+- {!Os.Fcm_notif}:
+  send push notifications to mobile devices.
+
+- {!Os.Comet}:
+  manage the bi-directional communication channel between client and
+  server. This is a low-level module that you probably don't need.
+
+{2 Services, handlers, sessions}
+
+- {!Os.Services}:
+  Eliom services pre-defined by Ocsigen Start. These produce the
+  default user interface of the template.
+  See {{:../eliom/server-services.html}the Eliom manual page on services} for
+  a general introduction to Eliom services.
+
+- {!Os.Handlers}:
+  The handlers (functions) that implement the services in
+  {!Os.Services}.
+  {{:../eliom/server-outputs.html}The Eliom manual page on service handlers}
+  explains how to implement handlers.
+
+- {!Os.Session}:
+  manage user sessions, e.g., execute actions when users connect or
+  disconnect.
+
+{2 Other utilities}
+
+- {!Os.Date}:
+  utilities for manipulating date and time values.
+
+- {!Os.Platform}:
+  obtain information about the platform we are on (Android, iOS, ...).
+
+- {!Os.Request_cache},
+  {!Os.User_proxy}:
+  different forms of caching data.
+
+- A {e ppx} syntax extension to implement RPC.

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -1,0 +1,21 @@
+;; Declarative wodoc config for the Ocsigen Start documentation (client/server).
+;;   wodoc build --config doc/wodoc --out <dir>/<label> --label <v> \
+;;               --menu https://ocsigen.org/wodoc/menu.html [--local]
+;; ocsigen-start ships server and client libraries (ocsigen-start.server /
+;; ocsigen-start.client) with the same module names, so the API is built with
+;; `odoc_driver ocsigen-start --remap` on the INSTALLED package. Each side gets
+;; its own API nav, a body colour and a switch; the manual nav is shared.
+(project ocsigen-start)
+(title Start)
+(pub /ocsigen-start)
+(odoc-driver ocsigen-start)
+(landing ocsigen-start/index.html)
+(manual-menu doc/manual/menu.wiki)
+(client-server
+  (server (lib ocsigen-start.server) (indexdoc doc/server.indexdoc) (heading "Server API") (wrapper Os))
+  (client (lib ocsigen-start.client) (indexdoc doc/client.indexdoc) (heading "Client API") (wrapper Os)))
+(hosted
+  (eliom           eliom           true  Eliom)
+  (ocsigen-toolkit ocsigen-toolkit true  Ot)
+  (ocsigen-start   ocsigen-start   true  Os)
+  (ocsigenserver   ocsigenserver   false Ocsigen))

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -9,8 +9,11 @@
 (title Start)
 (pub /ocsigen-start)
 (odoc-driver ocsigen-start)
-(landing ocsigen-start/index.html)
-(manual-menu doc/manual/menu.wiki)
+(landing intro.html)
+(nav
+ (section "Manual"
+  (link "Introduction" intro.html intro)
+  (link "Overview" index.html index)))
 (client-server
   (server (lib ocsigen-start.server) (indexdoc doc/server.indexdoc) (heading "Server API") (wrapper Os))
   (client (lib ocsigen-start.client) (indexdoc doc/client.indexdoc) (heading "Client API") (wrapper Os)))

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -17,8 +17,15 @@
 (client-server
   (server (lib ocsigen-start.server) (indexdoc doc/server.indexdoc) (heading "Server API") (wrapper Os))
   (client (lib ocsigen-start.client) (indexdoc doc/client.indexdoc) (heading "Client API") (wrapper Os)))
+;; Sibling Ocsigen projects whose ocaml.org xrefs are rewritten to relative
+;; links into their wodoc docs:  (pkg deploy-dir layout wrapper-module)
+;; layout = true/multilib (<dir>.<side>/) | false/root (modules at version
+;; root) | subdir (each opam package under its own <pkg>/, whole family).
 (hosted
   (eliom           eliom           true  Eliom)
   (ocsigen-toolkit ocsigen-toolkit true  Ot)
   (ocsigen-start   ocsigen-start   true  Os)
-  (ocsigenserver   ocsigenserver   false Ocsigen))
+  (ocsigenserver   ocsigenserver   false Ocsigen)
+  (js_of_ocaml     js_of_ocaml     subdir)
+  (tyxml           tyxml           subdir)
+  (reactiveData    reactiveData    root))

--- a/src/Os/comet.eliomi
+++ b/src/Os/comet.eliomi
@@ -34,9 +34,7 @@ val restart_process : unit -> unit
 (** [restart_process ()] restarts the client.
     For mobile application, it restarts the application by going to
     ["index.html"].
-    For other types of clients, <<a_api subproject="server" |
-    module Eliom.Service.reload_action>> is used as argument of <<a_api
-    subproject="server" | module Eliom.Client.exit_to>>
+    For other types of clients, {!Eliom.Service.reload_action} is used as argument of {!Eliom.Client.exit_to}
  *)
 
 val set_error_handler : (exn -> unit Lwt.t) -> unit

--- a/src/Os/types.eliom
+++ b/src/Os/types.eliom
@@ -39,7 +39,7 @@ module User = struct
     ; avatar : string option
     ; language : string option }
   [@@deriving json]
-  (** Type representing a user. See <<a_api | module User >>. *)
+  (** Type representing a user. See {!User}. *)
 end
 
 module Action_link_key = struct
@@ -59,5 +59,5 @@ module Group = struct
   (** Type representing a group ID *)
 
   type t = {id : id; name : string; desc : string option}
-  (** Type representing a group. See <<a_api | module Group >> *)
+  (** Type representing a group. See {!Group} *)
 end

--- a/src/Os/types.eliomi
+++ b/src/Os/types.eliomi
@@ -41,7 +41,7 @@ module User : sig
     ; avatar : string option
     ; language : string option }
   [@@deriving json]
-  (** Type representing a user. See <<a_api | module User >>. *)
+  (** Type representing a user. See {!User}. *)
 end
 
 (** Types related to action link keys *)
@@ -63,5 +63,5 @@ module Group : sig
   (** Type representing a group ID *)
 
   type t = {id : id; name : string; desc : string option}
-  (** Type representing a group. See <<a_api | module Group >> *)
+  (** Type representing a group. See {!Group} *)
 end

--- a/src/Os/user_proxy.eliom
+++ b/src/Os/user_proxy.eliom
@@ -18,8 +18,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-(** This module implements a cache of user using <<a_api project="eliom" |
-    module Eliom.Cscache>> which allows to keep synchronized the cache between
+(** This module implements a cache of user using {!Eliom.Cscache} which allows to keep synchronized the cache between
     the client and the server.
     Even if there is a cache implementing in {!User} to avoid to do database
     requests, this last one is implementing only server side.

--- a/src/Os/user_proxy.eliomi
+++ b/src/Os/user_proxy.eliomi
@@ -19,8 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-(** This module implements a cache of user using <<a_api project="eliom" |
-    module Eliom.Cscache>> which allows to keep synchronized the cache between
+(** This module implements a cache of user using {!Eliom.Cscache} which allows to keep synchronized the cache between
     the client and the server.
     Even if there is a cache implemented in {!User} to avoid to do database
     requests, this last one is implementing only server side. Same for

--- a/src/Os/user_view.eliomi
+++ b/src/Os/user_view.eliomi
@@ -184,8 +184,7 @@ val home_button :
 val avatar : Types.User.t -> [> `I | `Img] Eliom.Content.Html.F.elt
 (** [avatar user] creates an image HTML tag (with Eliom.Content.HTML.F) with an
     alt attribute to ["picture"] and with class ["os-avatar"]. If the user has
-    no avatar, the default icon representing the user (see <<a_api
-    project="ocsigen-toolkit" | val Ot.Icons.F.user >>) is returned.
+    no avatar, the default icon representing the user (see {!Ot.Icons.F.user}) is returned.
 
     @param user the user. *)
 


### PR DESCRIPTION
Part of the Ocsigen odoc/wodoc documentation migration (see the same PRs on eliom #860/#861 and ocsigen-toolkit #249/#250).

This branch carries the **dev** (deriving, `Os.Xxx`) documentation changes:
- convert `<<a_api>>`/`<<a_manual>>` wikidoc references in `src/Os/*.{eliomi,eliom}` to native odoc references (`{!Module}` / `{{!page-X}}`);
- add `doc/intro.mld` (converted from the wikidoc manual), `doc/index.mld` (landing page) and `doc/dune` declaring them in the `ocsigen-start` package, so manual + API build together with odoc and cross-references resolve.

The source stays valid for ocaml.org's stock odoc; the Ocsigen-themed site is built by wodoc. Draft pending the wider migration.