### PR TITLE
doc: odoc/wodoc migration — manual + API refs (latest / 8.0.0)

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,71 @@
+# Build the Ocsigen Start documentation (manual + server/client API) with
+# odoc_driver, theme it with the Ocsigen chrome (wodoc), and publish it on the
+# project's gh-pages branch, served at https://ocsigen.org/ocsigen-start/.
+# See doc/README.md.
+#
+# CI deploys ONLY the "dev" docs and ONLY from master. Stable versions are frozen
+# by hand at release time (see doc/README.md). Each run replaces only the dev/
+# directory; other version directories already on gh-pages are PRESERVED.
+name: Documentation
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+  build-deploy:
+    if: github.repository == 'ocsigen/ocsigen-start'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install dependencies
+        run: |
+          # The documented version is the INSTALLED ocsigen-start: install it from
+          # the ref being built so odoc_driver documents these sources.
+          opam install . --deps-only --with-doc
+          opam install . --with-doc
+          # odoc-driver with the cross-library link fix (not yet upstreamed).
+          opam pin add -n odoc https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
+          opam pin add -n odoc-driver https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
+          opam install odoc odoc-driver
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Build documentation (dev)
+        # wodoc build runs `odoc_driver ocsigen-start --remap` on the installed
+        # package (after preprocessing the installed manual .mld), assembles the
+        # themed site from doc/wodoc, fetches the shared menu from ocsigen.github.io.
+        run: >-
+          opam exec -- wodoc build --config doc/wodoc
+          --menu https://ocsigen.org/doc/menu.html
+          --out "$PWD/_doc-site/dev" --label dev
+
+      - name: Overlay manual assets (screenshots live on the wikidoc branch)
+        # The intro manual references files/screenshots/*.png (and the demo
+        # app downloads); these binaries are kept on the wikidoc branch, not in
+        # the .mli/.mld sources, so copy them into the built tree.
+        run: |
+          git fetch origin wikidoc
+          mkdir -p _doc-site/dev/files
+          git archive origin/wikidoc doc/dev/manual/files \
+            | tar -x --strip-components=4 -C _doc-site/dev/files
+
+      - name: Deploy to gh-pages (replace only dev/, keep the rest)
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: _doc-site/dev
+          target-folder: dev
+          clean: true

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -18,6 +18,13 @@ on:
         required: false
         default: ""
 
+# Serialise gh-pages writes: a push (rebuilds dev/) and a release
+# workflow_dispatch (freezes <version>/ and repoints latest) must never push to
+# gh-pages at the same time, or the second push fails non-fast-forward.
+concurrency:
+  group: doc-deploy-${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   build-deploy:
     if: github.repository == 'ocsigen/ocsigen-start' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version == '')
@@ -81,6 +88,10 @@ jobs:
     # No rebuild -- the docs of a release are exactly the dev docs at that point.
     if: github.repository == 'ocsigen/ocsigen-start' && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
     runs-on: ubuntu-latest
+    # Pass the user-supplied version through the environment; never interpolate
+    # it directly into a run: shell (avoids command injection from the input).
+    env:
+      VERSION: ${{ github.event.inputs.version }}
     permissions:
       contents: write
     steps:
@@ -106,7 +117,7 @@ jobs:
         # write the root index.html redirect if missing, refresh versions.json.
         run: >-
           opam exec -- wodoc release --site site --from dev
-          --version "${{ github.event.inputs.version }}"
+          --version "$VERSION"
 
       - name: Commit and push gh-pages
         run: |
@@ -115,5 +126,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --cached --quiet \
-            || git commit -m "Release doc ${{ github.event.inputs.version }} (freeze dev, repoint latest)"
+            || git commit -m "Release doc $VERSION (freeze dev, repoint latest)"
           git push

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -42,16 +42,26 @@ jobs:
         with:
           ocaml-compiler: "5.4.0"
 
+      - name: Set up Binaryen
+        # ocsigen-start depends on wasm_of_ocaml-compiler, whose build needs a
+        # recent binaryen (wasm-merge); distro binaryen is too old. Same action as
+        # js_of_ocaml's own CI.
+        uses: Aandreba/setup-binaryen@v1.0.0
+        with:
+          token: ${{ github.token }}
+
       - name: Install dependencies
         run: |
-          # The documented version is the INSTALLED ocsigen-start: install it from
-          # the ref being built so odoc_driver documents these sources.
+          # Install ocsigen-start (from the ref being built) so odoc_driver
+          # documents these sources. It is installed WITHOUT --with-doc: its server
+          # and client libraries share module names, so building its own @doc
+          # collides ("Multiple rules for .../Os_*/index.html"). wodoc builds the
+          # docs via `odoc_driver --remap` instead.
           opam install . --deps-only --with-doc
-          opam install . --with-doc
-          # odoc-driver with the cross-library link fix (not yet upstreamed).
-          opam pin add -n odoc https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
-          opam pin add -n odoc-driver https://github.com/balat/odoc.git#driver-sibling-lib-link-fix
-          opam install odoc odoc-driver
+          opam install .
+          # wodoc themes the pages. Its opam pin-depends pulls odoc / odoc-driver
+          # from the balat/odoc fork (the cross-library link fix, not yet upstream),
+          # so we do NOT pin odoc ourselves here.
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
           opam install wodoc
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,11 +11,16 @@ name: Documentation
 on:
   push:
     branches: [master]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Publish a stable version: freeze the dev docs now on gh-pages as /<version>/ and repoint `latest` (e.g. 1.2.3). Leave empty to just rebuild dev."
+        required: false
+        default: ""
 
 jobs:
   build-deploy:
-    if: github.repository == 'ocsigen/ocsigen-start'
+    if: github.repository == 'ocsigen/ocsigen-start' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version == '')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -69,3 +74,46 @@ jobs:
           folder: _doc-site/dev
           target-folder: dev
           clean: true
+
+  release:
+    # Manual run with a version: freeze the dev docs currently on gh-pages as the
+    # stable /<version>/ and repoint `latest` at it (refreshing versions.json).
+    # No rebuild -- the docs of a release are exactly the dev docs at that point.
+    if: github.repository == 'ocsigen/ocsigen-start' && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install wodoc
+        run: |
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: site
+          fetch-depth: 0
+
+      - name: Freeze dev as the stable version and repoint latest
+        # wodoc release: cp -a site/dev site/<version>, ln -sfn <version> latest,
+        # write the root index.html redirect if missing, refresh versions.json.
+        run: >-
+          opam exec -- wodoc release --site site --from dev
+          --version "${{ github.event.inputs.version }}"
+
+      - name: Commit and push gh-pages
+        run: |
+          cd site
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet \
+            || git commit -m "Release doc ${{ github.event.inputs.version }} (freeze dev, repoint latest)"
+          git push

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,83 @@
+# How the Ocsigen Start documentation is generated
+
+The Ocsigen Start documentation published at
+<https://ocsigen.org/ocsigen-start/> is built with **odoc** and themed with the
+Ocsigen site chrome by [**wodoc**](https://github.com/ocsigen/wodoc) (an odoc
+driver). The same odoc sources are also what ocaml.org renders.
+
+Ocsigen Start is a **client/server** project: it ships its server and client
+APIs as two libraries of the same package (`ocsigen-start.server` /
+`ocsigen-start.client`) with the **same module names**, so `dune build @doc`
+collides. The API is therefore built with `odoc_driver ocsigen-start --remap`
+(the engine ocaml.org uses) on the **installed** package — i.e. the documented
+version is whatever the build switch has installed.
+
+## Sources
+
+| What | Where | Format |
+|---|---|---|
+| Manual | the package's `(documentation)` `.mld` (`doc/*.mld`) | odoc pages |
+| Manual nav | the static `(nav …)` in [`doc/wodoc`](wodoc) | wodoc config |
+| Server / client API | the installed `ocsigen-start.server` / `.client` libraries | odoc comments |
+| Site configuration | [`doc/wodoc`](wodoc) | wodoc config (S-expression) |
+
+The whole site — per-side API navs, the client/server switch, the body colour,
+the shared manual nav, and the rewriting of sibling Ocsigen projects' cross-refs
+to relative links — is declared in [`doc/wodoc`](wodoc) and produced by a single
+`wodoc build`. There is **no `build.sh`** and no Python.
+
+## Build
+
+`wodoc build` documents the **installed** `ocsigen-start`, so install it first
+(from the ref you want to document) in a switch that also has `wodoc`:
+
+```
+opam install .                       # the version to document (NOT --with-doc:
+                                     # server+client share module names -> @doc collides)
+opam install wodoc                   # the odoc driver / theming
+wodoc build --config doc/wodoc --label dev --out _doc-site/dev \
+  --menu https://ocsigen.org/doc/menu.html
+```
+
+`wodoc build` runs `odoc_driver ocsigen-start --remap` on the installed package,
+assembles every page into the Ocsigen site and writes the version redirect. Add
+`--local` to fetch the shared `/css//img/` assets and preview offline.
+
+> **Toolchain (CI).** The cross-library link fix lives in the
+> [balat/odoc](https://github.com/balat/odoc) fork, which wodoc pulls in through
+> its opam `pin-depends`. Do **not** pin `odoc` yourself — that conflicts with
+> wodoc's pin. `wasm_of_ocaml-compiler` (a client-toolchain dep) needs a recent
+> binaryen, installed by the `Set up Binaryen` CI step.
+
+## Deployment (CI)
+
+[`.github/workflows/doc.yml`](../.github/workflows/doc.yml) builds and publishes to
+the project's **`gh-pages`** branch (served at `ocsigen.org/ocsigen-start/`). The
+CI triggers **only on `master`**, so pushing any other branch never deploys:
+
+- **push to `master`** → rebuilds and deploys the **`dev`** docs only.
+
+Stable versions are **not** built by CI on push: they are published by the
+`release` job (below). Each CI run replaces only the `dev/` directory; the other
+version directories (and the live `demo/`) already on `gh-pages` are preserved.
+
+## Releasing a stable version
+
+The CI builds only `dev/`. To publish a stable version, trigger the
+**Documentation** workflow's `release` job with the **version** input — either:
+
+- **CLI** (from a clone of the repo): `gh workflow run doc.yml -f version=1.2.3`
+- **GitHub UI**: repo → *Actions* → *Documentation* (left sidebar) → *Run workflow*
+  (top-right) → set **version** (e.g. `1.2.3`) → *Run workflow*.
+
+The `release` job freezes the current `dev/` docs as `/<version>/`, repoints the
+`latest` symlink, writes the root redirect and refreshes `versions.json` — via
+`wodoc release --from dev --version <version>`. No rebuild: the docs of a release
+are exactly the `dev` docs at that point.
+
+Equivalently, by hand on a `gh-pages` checkout:
+
+```
+wodoc release --site . --from dev --version <version>
+git add -A && git commit -m "Release doc <version>" && git push
+```

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,5 @@
+; Ocsigen Start manual pages (odoc .mld), compiled in place with the API by
+; `dune build @doc` and installed with the package, so they appear on ocaml.org
+; and resolve {{!page-X}} / {!Module} references against the API.
+(documentation
+ (package ocsigen-start))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -2,7 +2,7 @@
 
 Ocsigen Start is a ready-to-use application skeleton for building
 client-server web and mobile applications with {{:/eliom/}Eliom} and
-{{:../ocsigen-toolkit}Ocsigen Toolkit}. It ships with user management,
+{{:/ocsigen-toolkit/}Ocsigen Toolkit}. It ships with user management,
 notifications, a database schema and many code examples, so you can
 focus on your own features from day one.
 

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,8 +1,8 @@
 {0 Ocsigen Start}
 
 Ocsigen Start is a ready-to-use application skeleton for building
-client-server web and mobile applications with {{:/eliom/}Eliom} and
-{{:/ocsigen-toolkit/}Ocsigen Toolkit}. It ships with user management,
+client-server web and mobile applications with {{:https://ocsigen.org/eliom/}Eliom} and
+{{:https://ocsigen.org/ocsigen-toolkit/}Ocsigen Toolkit}. It ships with user management,
 notifications, a database schema and many code examples, so you can
 focus on your own features from day one.
 

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,24 @@
+{0 Ocsigen Start}
+
+Ocsigen Start is a ready-to-use application skeleton for building
+client-server web and mobile applications with {{:../eliom}Eliom} and
+{{:../ocsigen-toolkit}Ocsigen Toolkit}. It ships with user management,
+notifications, a database schema and many code examples, so you can
+focus on your own features from day one.
+
+Ocsigen Start is part of the {{:https://ocsigen.org}Ocsigen project}.
+
+{1 Documentation}
+
+- {{!page-intro}Introduction} — installation, getting started and an
+  overview of the modules Ocsigen Start provides.
+- The server and client API of every module (use the {e Server API} /
+  {e Client API} switch to move between the two sides).
+
+{1 Installation}
+
+Ocsigen Start is available via OPAM:
+
+{[
+opam install ocsigen-start
+]}

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,7 +1,7 @@
 {0 Ocsigen Start}
 
 Ocsigen Start is a ready-to-use application skeleton for building
-client-server web and mobile applications with {{:../eliom}Eliom} and
+client-server web and mobile applications with {{:/eliom/}Eliom} and
 {{:../ocsigen-toolkit}Ocsigen Toolkit}. It ships with user management,
 notifications, a database schema and many code examples, so you can
 focus on your own features from day one.

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -17,7 +17,7 @@ for iOS or Android (via {{:https://cordova.apache.org/}Cordova})..
 {1 Demo}
 
 If you want to test the demo application before installing Ocsigen Start,
-{b a live version is running {{:/ocsigen-start/demo/}here}}.
+{b a live version is running {{:https://ocsigen.org/ocsigen-start/demo/}here}}.
 
 You can also download the mobile app
 {{:https://play.google.com/store/apps/details?id=com.osdemo.mobile}on Google Play store} (for Android)
@@ -80,7 +80,7 @@ It includes a demo of many features from Eliom, Js_of_ocaml, Tyxml, Ocsigen Tool
 
 {1 Getting started}
 
-Read {{:/tuto/latest/start.html}this page} to learn how to build your first Ocsigen Start app in 5 minutes.
+Read {{:https://ocsigen.org/tuto/latest/start.html}this page} to learn how to build your first Ocsigen Start app in 5 minutes.
 
 {1 Implementation overview}
 
@@ -213,13 +213,13 @@ connection forms, etc.
 - {!Os_services}:
   Eliom services pre-defined by Ocsigen Start. These produce the
   default user interface of the template.
-  See {{:/eliom/latest/server-services.html}the Eliom manual page on services} for
+  See {{:https://ocsigen.org/eliom/latest/server-services.html}the Eliom manual page on services} for
   a general introduction to Eliom services.
 
 - {!Os_handlers}:
   The handlers (functions) that implement the services in
   {!Os_services}.
-  {{:/eliom/latest/server-outputs.html}The Eliom manual page on service handlers}
+  {{:https://ocsigen.org/eliom/latest/server-outputs.html}The Eliom manual page on service handlers}
   explains how to implement handlers.
 
 - {!Os_session}:

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -1,0 +1,241 @@
+
+
+{0 Introduction}
+
+Ocsigen Start is an application template written with Eliom, Js_of_ocaml,
+Ocsigen Toolkit, etc.
+It contains many standard features like user management, notifications,
+and many code examples.
+
+Use it to learn Ocsigen or to quickly create your own Minimum Viable Product.
+It is probably the fastest way to get started with Ocsigen.
+
+The application is cross-platform: it works as a Web app or as a mobile app
+for iOS or Android (via {{:https://cordova.apache.org/}Cordova})..
+
+
+{1 Demo}
+
+If you want to test the demo application before installing Ocsigen Start,
+{b a live version is running {{:../ocsigen-start/demo/}here}}.
+
+You can also download the mobile app
+{{:https://play.google.com/store/apps/details?id=com.osdemo.mobile}on Google Play store} (for Android)
+or download the
+{{:files/osdemo.apk}APK for Android}
+or the
+{{:files/osdemo-ios.tgz}iOS version} (to be installed using XCode).
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start1.png}
+{{files/screenshots/start1.png|Ocsigen Start}}}
+{{:files/screenshots/start2.png}
+{{files/screenshots/start2.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start-mobile-1.png}
+{{files/screenshots/start-mobile-1.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-2.png}
+{{files/screenshots/start-mobile-2.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-4.png}
+{{files/screenshots/start-mobile-4.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+
+
+Ocsigen Start is composed by two main parts:
+
+- The generated code which gives a default behaviour to your application. Adapt it to your needs and remove the parts you don't need. Feel free to redistribute it as you wish.{%html:<br/>%}
+It includes a demo of many features from Eliom, Js_of_ocaml, Tyxml, Ocsigen Toolkit. Use it to learn quickly the main principles of multi-tier programming.
+
+- A library with:
+- User management: authentication, registration of new users with activation links sent by email, recover lost password, page to update settings, etc.
+- Tips for new users
+- Push notifications to send information to other users
+- ...
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start3.png}
+{{files/screenshots/start3.png|Ocsigen Start}}}
+{{:files/screenshots/start4.png}
+{{files/screenshots/start4.png|Ocsigen Start}}}
+{{:files/screenshots/start5.png}
+{{files/screenshots/start5.png|Ocsigen Start}}}
+{{:files/screenshots/start6.png}
+{{files/screenshots/start6.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start-mobile-3.png}
+{{files/screenshots/start-mobile-3.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-6.png}
+{{files/screenshots/start-mobile-6.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-7.png}
+{{files/screenshots/start-mobile-7.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-8.png}
+{{files/screenshots/start-mobile-8.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+
+{1 Getting started}
+
+Read {{:../tuto/start.html}this page} to learn how to build your first Ocsigen Start app in 5 minutes.
+
+{1 Implementation overview}
+
+{2 Template}
+
+The library portion of Ocsigen Start contains core functionality that
+is common across Ocsigen Start applications, while the template can be
+customized for the specific application at hand.
+
+The template additionally contains a demonstration of relevant
+{{:https://github.com/ocsigen/ocsigen-toolkit}Ocsigen Toolkit}
+widgets. The demo portion can easily be removed.
+
+{2 Database}
+
+For implementing users, a database is needed. Specifically, we use
+{{:https://www.postgresql.org/}PostgreSQL} via the
+{{:http://pgocaml.forge.ocamlcore.org/}PGOCaml} library. The template
+and the library make common assumptions about the database schema. The
+database thus needs to be instantiated in a certain way; this is
+automatically done by appropriate targets in the template's build
+system.
+
+The same database can used for the specific needs of the application
+at hand. For that, new tables can be added. The original ones should
+remain in place for Ocsigen Start to work correctly.
+
+{2 Internationalization (i18n)}
+
+The template is available in multiple languages (English and French) using
+{{:https://github.com/besport/ocsigen-i18n}ocsigen-i18n}. All translations used
+in the template are defined in the file [assets/PROJECT_NAME_i18n.tsv]. The
+Makefile rule [i18n-udpate] generates the i18n module. You need to use it
+every time the TSV file is updated.
+
+See [Makefile.i18n] for rules about i18n and [Makefile.options] to
+personalize the internalization of your application (for example add new
+languages, change default language, change TSV filename).
+
+{2 Managing e-mails}
+
+The template application keeps track of users' e-mails and implements
+e-mail validation. For that, [sendmail] (or another mail transfer
+agent compatible with it) needs to be installed on the host.
+
+{2 Style}
+
+The application provides a standard style matching contemporary
+aesthetics. For this, we use {{:http://sass-lang.com/}SASS}. The style
+can be customized by modifying the SASS files that are part of the
+template.
+
+{1 Installation}
+
+Ocsigen Start can be installed via
+{{:https://opam.ocaml.org/}OPAM}. The package name is [ocsigen-start].
+The template application can be instantiated via [eliom-distillery]:
+
+{@shell[
+eliom-distillery -name $APP_NAME -template os.pgocaml
+]}
+
+(Replace $APP_NAME by the name of your application).
+
+For details on launching the application, refer to the template's
+{{:https://github.com/ocsigen/ocsigen-start/blob/master/template.distillery/README.md}README}.
+
+{1 Library overview}
+
+We provide a tour of the Ocsigen Start library. All modules have
+server- and client-side versions. (In the API documentation, there are
+links near the top of each module page for selecting the side.)
+
+The template uses all these modules, and can thus act as a good
+starting guide. Look around!
+
+{2 User interface}
+
+Various modules for producing icons, messages, custom pages, tips,
+connection forms, etc.
+
+- {!Os_icons}:
+  manage CSS icons.
+- {!Os_msg}:
+  write messages in the browser console.
+- {!Os_page}:
+  utilities for building HTML pages that follow the standard Ocsigen
+  Start layout.
+- {!Os_tips}:
+  display tips to the user.
+- {!Os_user_view}:
+  functions for creating password forms and other common UI elements
+  appearing in applications and for managing the user connection box.
+- {!Os_uploader}:
+  ImageMagick-based tools for manipulating avatars.
+
+{2 Users and groups}
+
+- {!Os_user},
+  {!Os_current_user},
+  {!Os_group}:
+  manage users and groups thereof.
+
+- {!Os_db}:
+  directly access the database. In many cases, it is a better idea to
+  use higher-level modules (e.g.,
+  {!Os_user}).
+
+- {!Os_types}:
+  core types shared by {!Os_db}
+  and the higher-level modules.
+
+{2 Communication}
+
+- {!Os_notif}:
+  send notifications to connected users.
+
+- {!Os_email}:
+  send e-mails.
+
+- {!Os_fcm_notif}:
+  send push notifications to mobile devices.
+
+- {!Os_comet}:
+  manage the bi-directional communication channel between client and
+  server. This is a low-level module that you probably don't need.
+
+{2 Services, handlers, sessions}
+
+- {!Os_services}:
+  Eliom services pre-defined by Ocsigen Start. These produce the
+  default user interface of the template.
+  See {{:../eliom/server-services.html}the Eliom manual page on services} for
+  a general introduction to Eliom services.
+
+- {!Os_handlers}:
+  The handlers (functions) that implement the services in
+  {!Os_services}.
+  {{:../eliom/server-outputs.html}The Eliom manual page on service handlers}
+  explains how to implement handlers.
+
+- {!Os_session}:
+  manage user sessions, e.g., execute actions when users connect or
+  disconnect.
+
+{2 Other utilities}
+
+- {!Os_date}:
+  utilities for manipulating date and time values.
+
+- {!Os_platform}:
+  obtain information about the platform we are on (Android, iOS, ...).
+
+- {!Os_request_cache},
+  {!Os_user_proxy}:
+  different forms of caching data.
+
+- A {e ppx} syntax extension to implement RPC.

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -80,7 +80,7 @@ It includes a demo of many features from Eliom, Js_of_ocaml, Tyxml, Ocsigen Tool
 
 {1 Getting started}
 
-Read {{:../tuto/start.html}this page} to learn how to build your first Ocsigen Start app in 5 minutes.
+Read {{:/tuto/latest/start.html}this page} to learn how to build your first Ocsigen Start app in 5 minutes.
 
 {1 Implementation overview}
 
@@ -213,13 +213,13 @@ connection forms, etc.
 - {!Os_services}:
   Eliom services pre-defined by Ocsigen Start. These produce the
   default user interface of the template.
-  See {{:../eliom/server-services.html}the Eliom manual page on services} for
+  See {{:/eliom/latest/server-services.html}the Eliom manual page on services} for
   a general introduction to Eliom services.
 
 - {!Os_handlers}:
   The handlers (functions) that implement the services in
   {!Os_services}.
-  {{:../eliom/server-outputs.html}The Eliom manual page on service handlers}
+  {{:/eliom/latest/server-outputs.html}The Eliom manual page on service handlers}
   explains how to implement handlers.
 
 - {!Os_session}:

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -28,18 +28,18 @@ or the
 
 {%wodoc:div class="screenshots"%}
 {{:files/screenshots/start1.png}
-{{files/screenshots/start1.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start1.png" alt="Ocsigen Start"%}}
 {{:files/screenshots/start2.png}
-{{files/screenshots/start2.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start2.png" alt="Ocsigen Start"%}}
 {%wodoc:end%}
 
 {%wodoc:div class="screenshots"%}
 {{:files/screenshots/start-mobile-1.png}
-{{files/screenshots/start-mobile-1.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start-mobile-1.png" alt="Ocsigen Start"%}}
 {{:files/screenshots/start-mobile-2.png}
-{{files/screenshots/start-mobile-2.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start-mobile-2.png" alt="Ocsigen Start"%}}
 {{:files/screenshots/start-mobile-4.png}
-{{files/screenshots/start-mobile-4.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start-mobile-4.png" alt="Ocsigen Start"%}}
 {%wodoc:end%}
 
 
@@ -57,24 +57,24 @@ It includes a demo of many features from Eliom, Js_of_ocaml, Tyxml, Ocsigen Tool
 
 {%wodoc:div class="screenshots"%}
 {{:files/screenshots/start3.png}
-{{files/screenshots/start3.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start3.png" alt="Ocsigen Start"%}}
 {{:files/screenshots/start4.png}
-{{files/screenshots/start4.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start4.png" alt="Ocsigen Start"%}}
 {{:files/screenshots/start5.png}
-{{files/screenshots/start5.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start5.png" alt="Ocsigen Start"%}}
 {{:files/screenshots/start6.png}
-{{files/screenshots/start6.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start6.png" alt="Ocsigen Start"%}}
 {%wodoc:end%}
 
 {%wodoc:div class="screenshots"%}
 {{:files/screenshots/start-mobile-3.png}
-{{files/screenshots/start-mobile-3.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start-mobile-3.png" alt="Ocsigen Start"%}}
 {{:files/screenshots/start-mobile-6.png}
-{{files/screenshots/start-mobile-6.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start-mobile-6.png" alt="Ocsigen Start"%}}
 {{:files/screenshots/start-mobile-7.png}
-{{files/screenshots/start-mobile-7.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start-mobile-7.png" alt="Ocsigen Start"%}}
 {{:files/screenshots/start-mobile-8.png}
-{{files/screenshots/start-mobile-8.png|Ocsigen Start}}}
+{%wodoc:img src="files/screenshots/start-mobile-8.png" alt="Ocsigen Start"%}}
 {%wodoc:end%}
 
 

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -17,7 +17,7 @@ for iOS or Android (via {{:https://cordova.apache.org/}Cordova})..
 {1 Demo}
 
 If you want to test the demo application before installing Ocsigen Start,
-{b a live version is running {{:../ocsigen-start/demo/}here}}.
+{b a live version is running {{:/ocsigen-start/demo/}here}}.
 
 You can also download the mobile app
 {{:https://play.google.com/store/apps/details?id=com.osdemo.mobile}on Google Play store} (for Android)

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -11,6 +11,15 @@
 (pub /ocsigen-start)
 (odoc-driver ocsigen-start)
 (landing intro.html)
+
+;; The shared manual nav (the two manual pages; the API module lists come from
+;; the per-side (indexdoc …) below). Only `dev` is rebuilt, so this static nav
+;; always matches the current manual.
+(nav
+ (section "Manual"
+  (link "Introduction" intro.html intro)
+  (link "Overview" index.html index)))
+
 (client-server
   (server (lib ocsigen-start.server) (indexdoc doc/indexdoc.server) (heading "Server API"))
   (client (lib ocsigen-start.client) (indexdoc doc/indexdoc.client) (heading "Client API")))

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -10,7 +10,7 @@
 (title Start)
 (pub /ocsigen-start)
 (odoc-driver ocsigen-start)
-(landing ocsigen-start/index.html)
+(landing intro.html)
 (client-server
   (server (lib ocsigen-start.server) (indexdoc doc/indexdoc.server) (heading "Server API"))
   (client (lib ocsigen-start.client) (indexdoc doc/indexdoc.client) (heading "Client API")))

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -1,0 +1,21 @@
+;; Declarative wodoc config for the Ocsigen Start documentation (client/server).
+;;   wodoc build --config doc/wodoc --out <dir>/<label> --label <v> \
+;;               --menu https://ocsigen.org/doc/menu.html [--local]
+;; ocsigen-start ships server and client libraries (ocsigen-start.server /
+;; ocsigen-start.client) with the same module names, so the API is built with
+;; `odoc_driver ocsigen-start --remap` on the INSTALLED package. Modules are flat
+;; (Os_*), so no wrapper. Each side gets its own API nav, a body colour and a
+;; switch; the manual (index/intro) is shared.
+(project ocsigen-start)
+(title Start)
+(pub /ocsigen-start)
+(odoc-driver ocsigen-start)
+(landing ocsigen-start/index.html)
+(client-server
+  (server (lib ocsigen-start.server) (indexdoc doc/indexdoc.server) (heading "Server API"))
+  (client (lib ocsigen-start.client) (indexdoc doc/indexdoc.client) (heading "Client API")))
+(hosted
+  (eliom           eliom           true  Eliom)
+  (ocsigen-toolkit ocsigen-toolkit true  Ot)
+  (ocsigen-start   ocsigen-start   true  Os)
+  (ocsigenserver   ocsigenserver   false Ocsigen))

--- a/src/os_comet.eliomi
+++ b/src/os_comet.eliomi
@@ -34,9 +34,7 @@ val restart_process : unit -> unit
 (** [restart_process ()] restarts the client.
     For mobile application, it restarts the application by going to
     ["index.html"].
-    For other types of clients, <<a_api subproject="server" |
-    module Eliom_service.reload_action>> is used as argument of <<a_api
-    subproject="server" | module Eliom_client.exit_to>>
+    For other types of clients, {!Eliom_service.reload_action} is used as argument of {!Eliom_client.exit_to}
  *)
 
 val set_error_handler : (exn -> unit Lwt.t) -> unit

--- a/src/os_types.eliom
+++ b/src/os_types.eliom
@@ -39,7 +39,7 @@ module User = struct
     ; avatar : string option
     ; language : string option }
   [@@deriving json]
-  (** Type representing a user. See <<a_api | module Os_user >>. *)
+  (** Type representing a user. See {!Os_user}. *)
 end
 
 module Action_link_key = struct
@@ -59,5 +59,5 @@ module Group = struct
   (** Type representing a group ID *)
 
   type t = {id : id; name : string; desc : string option}
-  (** Type representing a group. See <<a_api | module Os_group >> *)
+  (** Type representing a group. See {!Os_group} *)
 end

--- a/src/os_types.eliomi
+++ b/src/os_types.eliomi
@@ -41,7 +41,7 @@ module User : sig
     ; avatar : string option
     ; language : string option }
   [@@deriving json]
-  (** Type representing a user. See <<a_api | module Os_user >>. *)
+  (** Type representing a user. See {!Os_user}. *)
 end
 
 (** Types related to action link keys *)
@@ -63,5 +63,5 @@ module Group : sig
   (** Type representing a group ID *)
 
   type t = {id : id; name : string; desc : string option}
-  (** Type representing a group. See <<a_api | module Os_group >> *)
+  (** Type representing a group. See {!Os_group} *)
 end

--- a/src/os_user_proxy.eliom
+++ b/src/os_user_proxy.eliom
@@ -18,8 +18,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-(** This module implements a cache of user using <<a_api project="eliom" |
-    module Eliom_cscache>> which allows to keep synchronized the cache between
+(** This module implements a cache of user using {!Eliom_cscache} which allows to keep synchronized the cache between
     the client and the server.
     Even if there is a cache implementing in {!Os_user} to avoid to do database
     requests, this last one is implementing only server side.

--- a/src/os_user_proxy.eliomi
+++ b/src/os_user_proxy.eliomi
@@ -19,8 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-(** This module implements a cache of user using <<a_api project="eliom" |
-    module Eliom_cscache>> which allows to keep synchronized the cache between
+(** This module implements a cache of user using {!Eliom_cscache} which allows to keep synchronized the cache between
     the client and the server.
     Even if there is a cache implemented in {!Os_user} to avoid to do database
     requests, this last one is implementing only server side. Same for

--- a/src/os_user_view.eliomi
+++ b/src/os_user_view.eliomi
@@ -184,8 +184,7 @@ val home_button :
 val avatar : Os_types.User.t -> [> `I | `Img] Eliom_content.Html.F.elt
 (** [avatar user] creates an image HTML tag (with Eliom_content.HTML.F) with an
     alt attribute to ["picture"] and with class ["os-avatar"]. If the user has
-    no avatar, the default icon representing the user (see <<a_api
-    project="ocsigen-toolkit" | val Ot_icons.F.user >>) is returned.
+    no avatar, the default icon representing the user (see {!Ot_icons.F.user}) is returned.
 
     @param user the user. *)
 


### PR DESCRIPTION
Part of the Ocsigen odoc/wodoc documentation migration (see eliom #860/#861, ocsigen-toolkit #249/#250).

This branch carries the **latest/release** (master, flat `Os_xxx`) documentation changes — same shape as the dev PR but with the released module names and the 6.x manual:
- convert `<<a_api>>`/`<<a_manual>>` wikidoc references in `src/os_*.{eliomi,eliom}` to native odoc references;
- add `doc/intro.mld`, `doc/index.mld` and `doc/dune` (manual in the `ocsigen-start` package).

Draft pending the wider migration.