### PR TITLE
Declare ocsigen-dune-rules as a build dependency

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,5 @@
+; Ocsigen Start manual pages (odoc .mld), compiled in place with the API by
+; `dune build @doc` and installed with the package, so they appear on ocaml.org
+; and resolve {{!page-X}} / {!Module} references against the API.
+(documentation
+ (package ocsigen-start))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,24 @@
+{0 Ocsigen Start}
+
+Ocsigen Start is a ready-to-use application skeleton for building
+client-server web and mobile applications with {{:../eliom}Eliom} and
+{{:../ocsigen-toolkit}Ocsigen Toolkit}. It ships with user management,
+notifications, a database schema and many code examples, so you can
+focus on your own features from day one.
+
+Ocsigen Start is part of the {{:https://ocsigen.org}Ocsigen project}.
+
+{1 Documentation}
+
+- {{!page-intro}Introduction} — installation, getting started and an
+  overview of the modules Ocsigen Start provides.
+- The server and client API of every module (use the {e Server API} /
+  {e Client API} switch to move between the two sides).
+
+{1 Installation}
+
+Ocsigen Start is available via OPAM:
+
+{[
+opam install ocsigen-start
+]}

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -1,0 +1,241 @@
+
+
+{0 Introduction}
+
+Ocsigen Start is an application template written with Eliom, Js_of_ocaml,
+Ocsigen Toolkit, etc.
+It contains many standard features like user management, notifications,
+and many code examples.
+
+Use it to learn Ocsigen or to quickly create your own Minimum Viable Product.
+It is probably the fastest way to get started with Ocsigen.
+
+The application is cross-platform: it works as a Web app or as a mobile app
+for iOS or Android (via {{:https://cordova.apache.org/}Cordova})..
+
+
+{1 Demo}
+
+If you want to test the demo application before installing Ocsigen Start,
+{b a live version is running {{:../ocsigen-start/demo/}here}}.
+
+You can also download the mobile app
+{{:https://play.google.com/store/apps/details?id=com.osdemo.mobile}on Google Play store} (for Android)
+or download the
+{{:files/osdemo.apk}APK for Android}
+or the
+{{:files/osdemo-ios.tgz}iOS version} (to be installed using XCode).
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start1.png}
+{{files/screenshots/start1.png|Ocsigen Start}}}
+{{:files/screenshots/start2.png}
+{{files/screenshots/start2.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start-mobile-1.png}
+{{files/screenshots/start-mobile-1.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-2.png}
+{{files/screenshots/start-mobile-2.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-4.png}
+{{files/screenshots/start-mobile-4.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+
+
+Ocsigen Start is composed by two main parts:
+
+- The generated code which gives a default behaviour to your application. Adapt it to your needs and remove the parts you don't need. Feel free to redistribute it as you wish.{%html:<br/>%}
+It includes a demo of many features from Eliom, Js_of_ocaml, Tyxml, Ocsigen Toolkit. Use it to learn quickly the main principles of multi-tier programming.
+
+- A library with:
+- User management: authentication, registration of new users with activation links sent by email, recover lost password, page to update settings, etc.
+- Tips for new users
+- Push notifications to send information to other users
+- ...
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start3.png}
+{{files/screenshots/start3.png|Ocsigen Start}}}
+{{:files/screenshots/start4.png}
+{{files/screenshots/start4.png|Ocsigen Start}}}
+{{:files/screenshots/start5.png}
+{{files/screenshots/start5.png|Ocsigen Start}}}
+{{:files/screenshots/start6.png}
+{{files/screenshots/start6.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+{%wodoc:div class="screenshots"%}
+{{:files/screenshots/start-mobile-3.png}
+{{files/screenshots/start-mobile-3.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-6.png}
+{{files/screenshots/start-mobile-6.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-7.png}
+{{files/screenshots/start-mobile-7.png|Ocsigen Start}}}
+{{:files/screenshots/start-mobile-8.png}
+{{files/screenshots/start-mobile-8.png|Ocsigen Start}}}
+{%wodoc:end%}
+
+
+{1 Getting started}
+
+Read {{:../tuto/start.html}this page} to learn how to build your first Ocsigen Start app in 5 minutes.
+
+{1 Implementation overview}
+
+{2 Template}
+
+The library portion of Ocsigen Start contains core functionality that
+is common across Ocsigen Start applications, while the template can be
+customized for the specific application at hand.
+
+The template additionally contains a demonstration of relevant
+{{:https://github.com/ocsigen/ocsigen-toolkit}Ocsigen Toolkit}
+widgets. The demo portion can easily be removed.
+
+{2 Database}
+
+For implementing users, a database is needed. Specifically, we use
+{{:https://www.postgresql.org/}PostgreSQL} via the
+{{:http://pgocaml.forge.ocamlcore.org/}PGOCaml} library. The template
+and the library make common assumptions about the database schema. The
+database thus needs to be instantiated in a certain way; this is
+automatically done by appropriate targets in the template's build
+system.
+
+The same database can used for the specific needs of the application
+at hand. For that, new tables can be added. The original ones should
+remain in place for Ocsigen Start to work correctly.
+
+{2 Internationalization (i18n)}
+
+The template is available in multiple languages (English and French) using
+{{:https://github.com/besport/ocsigen-i18n}ocsigen-i18n}. All translations used
+in the template are defined in the file [assets/PROJECT_NAME_i18n.tsv]. The
+Makefile rule [i18n-udpate] generates the i18n module. You need to use it
+every time the TSV file is updated.
+
+See [Makefile.i18n] for rules about i18n and [Makefile.options] to
+personalize the internalization of your application (for example add new
+languages, change default language, change TSV filename).
+
+{2 Managing e-mails}
+
+The template application keeps track of users' e-mails and implements
+e-mail validation. For that, [sendmail] (or another mail transfer
+agent compatible with it) needs to be installed on the host.
+
+{2 Style}
+
+The application provides a standard style matching contemporary
+aesthetics. For this, we use {{:http://sass-lang.com/}SASS}. The style
+can be customized by modifying the SASS files that are part of the
+template.
+
+{1 Installation}
+
+Ocsigen Start can be installed via
+{{:https://opam.ocaml.org/}OPAM}. The package name is [ocsigen-start].
+The template application can be instantiated via [eliom-distillery]:
+
+{@shell[
+eliom-distillery -name $APP_NAME -template os.pgocaml
+]}
+
+(Replace $APP_NAME by the name of your application).
+
+For details on launching the application, refer to the template's
+{{:https://github.com/ocsigen/ocsigen-start/blob/master/template.distillery/README.md}README}.
+
+{1 Library overview}
+
+We provide a tour of the Ocsigen Start library. All modules have
+server- and client-side versions. (In the API documentation, there are
+links near the top of each module page for selecting the side.)
+
+The template uses all these modules, and can thus act as a good
+starting guide. Look around!
+
+{2 User interface}
+
+Various modules for producing icons, messages, custom pages, tips,
+connection forms, etc.
+
+- {!Os_icons}:
+  manage CSS icons.
+- {!Os_msg}:
+  write messages in the browser console.
+- {!Os_page}:
+  utilities for building HTML pages that follow the standard Ocsigen
+  Start layout.
+- {!Os_tips}:
+  display tips to the user.
+- {!Os_user_view}:
+  functions for creating password forms and other common UI elements
+  appearing in applications and for managing the user connection box.
+- {!Os_uploader}:
+  ImageMagick-based tools for manipulating avatars.
+
+{2 Users and groups}
+
+- {!Os_user},
+  {!Os_current_user},
+  {!Os_group}:
+  manage users and groups thereof.
+
+- {!Os_db}:
+  directly access the database. In many cases, it is a better idea to
+  use higher-level modules (e.g.,
+  {!Os_user}).
+
+- {!Os_types}:
+  core types shared by {!Os_db}
+  and the higher-level modules.
+
+{2 Communication}
+
+- {!Os_notif}:
+  send notifications to connected users.
+
+- {!Os_email}:
+  send e-mails.
+
+- {!Os_fcm_notif}:
+  send push notifications to mobile devices.
+
+- {!Os_comet}:
+  manage the bi-directional communication channel between client and
+  server. This is a low-level module that you probably don't need.
+
+{2 Services, handlers, sessions}
+
+- {!Os_services}:
+  Eliom services pre-defined by Ocsigen Start. These produce the
+  default user interface of the template.
+  See {{:../eliom/server-services.html}the Eliom manual page on services} for
+  a general introduction to Eliom services.
+
+- {!Os_handlers}:
+  The handlers (functions) that implement the services in
+  {!Os_services}.
+  {{:../eliom/server-outputs.html}The Eliom manual page on service handlers}
+  explains how to implement handlers.
+
+- {!Os_session}:
+  manage user sessions, e.g., execute actions when users connect or
+  disconnect.
+
+{2 Other utilities}
+
+- {!Os_date}:
+  utilities for manipulating date and time values.
+
+- {!Os_platform}:
+  obtain information about the platform we are on (Android, iOS, ...).
+
+- {!Os_request_cache},
+  {!Os_user_proxy}:
+  different forms of caching data.
+
+- A {e ppx} syntax extension to implement RPC.

--- a/dune-project
+++ b/dune-project
@@ -57,6 +57,7 @@
    (and
     (>= "1.0")
     (< "2.0")))
+  (ocsigen-dune-rules :build)
   cohttp-lwt-unix
   (js_of_ocaml
    (>= "6.3.2"))

--- a/ocsigen-start.opam
+++ b/ocsigen-start.opam
@@ -25,6 +25,7 @@ depends: [
   "ocsigen-ppx-rpc" {>= "1.1"}
   "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
+  "ocsigen-dune-rules" {build}
   "cohttp-lwt-unix"
   "js_of_ocaml" {>= "6.3.2"}
   "re" {>= "1.7.2"}

--- a/src/os_comet.eliomi
+++ b/src/os_comet.eliomi
@@ -34,9 +34,7 @@ val restart_process : unit -> unit
 (** [restart_process ()] restarts the client.
     For mobile application, it restarts the application by going to
     ["index.html"].
-    For other types of clients, <<a_api subproject="server" |
-    module Eliom_service.reload_action>> is used as argument of <<a_api
-    subproject="server" | module Eliom_client.exit_to>>
+    For other types of clients, {!Eliom_service.reload_action} is used as argument of {!Eliom_client.exit_to}
  *)
 
 val set_error_handler : (exn -> unit Lwt.t) -> unit

--- a/src/os_types.eliom
+++ b/src/os_types.eliom
@@ -39,7 +39,7 @@ module User = struct
     ; avatar : string option
     ; language : string option }
   [@@deriving json]
-  (** Type representing a user. See <<a_api | module Os_user >>. *)
+  (** Type representing a user. See {!Os_user}. *)
 end
 
 module Action_link_key = struct
@@ -59,5 +59,5 @@ module Group = struct
   (** Type representing a group ID *)
 
   type t = {id : id; name : string; desc : string option}
-  (** Type representing a group. See <<a_api | module Os_group >> *)
+  (** Type representing a group. See {!Os_group} *)
 end

--- a/src/os_types.eliomi
+++ b/src/os_types.eliomi
@@ -41,7 +41,7 @@ module User : sig
     ; avatar : string option
     ; language : string option }
   [@@deriving json]
-  (** Type representing a user. See <<a_api | module Os_user >>. *)
+  (** Type representing a user. See {!Os_user}. *)
 end
 
 (** Types related to action link keys *)
@@ -63,5 +63,5 @@ module Group : sig
   (** Type representing a group ID *)
 
   type t = {id : id; name : string; desc : string option}
-  (** Type representing a group. See <<a_api | module Os_group >> *)
+  (** Type representing a group. See {!Os_group} *)
 end

--- a/src/os_user_proxy.eliom
+++ b/src/os_user_proxy.eliom
@@ -18,8 +18,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-(** This module implements a cache of user using <<a_api project="eliom" |
-    module Eliom_cscache>> which allows to keep synchronized the cache between
+(** This module implements a cache of user using {!Eliom_cscache} which allows to keep synchronized the cache between
     the client and the server.
     Even if there is a cache implementing in {!Os_user} to avoid to do database
     requests, this last one is implementing only server side.

--- a/src/os_user_proxy.eliomi
+++ b/src/os_user_proxy.eliomi
@@ -19,8 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-(** This module implements a cache of user using <<a_api project="eliom" |
-    module Eliom_cscache>> which allows to keep synchronized the cache between
+(** This module implements a cache of user using {!Eliom_cscache} which allows to keep synchronized the cache between
     the client and the server.
     Even if there is a cache implemented in {!Os_user} to avoid to do database
     requests, this last one is implementing only server side. Same for

--- a/src/os_user_view.eliomi
+++ b/src/os_user_view.eliomi
@@ -184,8 +184,7 @@ val home_button :
 val avatar : Os_types.User.t -> [> `I | `Img] Eliom_content.Html.F.elt
 (** [avatar user] creates an image HTML tag (with Eliom_content.HTML.F) with an
     alt attribute to ["picture"] and with class ["os-avatar"]. If the user has
-    no avatar, the default icon representing the user (see <<a_api
-    project="ocsigen-toolkit" | val Ot_icons.F.user >>) is returned.
+    no avatar, the default icon representing the user (see {!Ot_icons.F.user}) is returned.
 
     @param user the user. *)
 


### PR DESCRIPTION
The build runs the ocsigen-dune-rules generator but never declared it; a clean opam install failed with 'Program ocsigen-dune-rules not found'.