### PR TITLE
Makefile: recompile CSS when SASS sources change

### DIFF
--- a/template.distillery/Makefile.style
+++ b/template.distillery/Makefile.style
@@ -65,7 +65,10 @@ endif
 # If SASS is not activated, it will concatenate all CSS files (listed in
 # $(CSS_FILES)) in $(LOCAL_CSS).
 # In both cases, external CSS files ($(EXTERNAL_CSS_FILES)) are copied.
-$(LOCAL_CSS): $(PACKAGE_JSON) $(NPM_POSTCSS) $(NPM_AUTOPREFIXER) $(LOCAL_STATIC_CSS)/.import-external-css | check_sass
+# The SASS sources are listed as prerequisites so that editing the main
+# stylesheet or any partial under $(SASSDIR) triggers a recompile;
+# otherwise make keeps the stale compiled CSS until it is deleted by hand.
+$(LOCAL_CSS): $(SASS_SRC) $(wildcard $(SASSDIR)/*.scss) $(wildcard $(SASSDIR)/lib/*.scss) $(PACKAGE_JSON) $(NPM_POSTCSS) $(NPM_AUTOPREFIXER) $(LOCAL_STATIC_CSS)/.import-external-css | check_sass
 ifeq "$(USE_SASS)" "yes"
 ifeq ($(shell which sassc),)
 	[ -d $(SASSDIR) ] && \


### PR DESCRIPTION
## Problem

The generated `Makefile.style` `$(LOCAL_CSS)` rule lists only the npm and external-CSS prerequisites — never the SASS sources:

```make
$(LOCAL_CSS): $(PACKAGE_JSON) $(NPM_POSTCSS) $(NPM_AUTOPREFIXER) $(LOCAL_STATIC_CSS)/.import-external-css | check_sass
```

So editing the main stylesheet or adding/editing a partial under `sass/` does **not** mark the compiled CSS out of date. `make` / `make opt` (and `config-files`, which depends on the hashed CSS) keep serving the stale CSS, and the only fix is to delete the compiled file by hand. Fresh checkouts and clean builds work (the CSS is built once), so this only bites incremental `.scss` edits — which is the common case during development.

## Fix

List the SASS sources as prerequisites of `$(LOCAL_CSS)`:

```make
$(LOCAL_CSS): $(SASS_SRC) $(wildcard $(SASSDIR)/*.scss) $(wildcard $(SASSDIR)/lib/*.scss) $(PACKAGE_JSON) $(NPM_POSTCSS) $(NPM_AUTOPREFIXER) $(LOCAL_STATIC_CSS)/.import-external-css | check_sass
```

Now any `.scss` edit triggers a recompile. The wildcards expand to nothing when those directories are absent, so projects without partials are unaffected. This mirrors the dedicated SASS rule used in some Ocsigen apps (besport's `Makefile.sass`), which already lists the sources as prerequisites.