### PR TITLE
doc: order the sidebar and make index.mld the landing page (for ocaml.org)

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,3 +1,5 @@
+@children_order intro
+
 {0 Ocsigen Start}
 
 Ocsigen Start is a ready-to-use application skeleton for building

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -9,11 +9,10 @@
 (title Start)
 (pub /ocsigen-start)
 (odoc-driver ocsigen-start)
-(landing intro.html)
+(landing index.html)
 (nav
  (section "Manual"
-  (link "Introduction" intro.html intro)
-  (link "Overview" index.html index)))
+  (link "Introduction" intro.html intro)))
 (client-server
   (server (lib ocsigen-start.server) (indexdoc doc/server.indexdoc) (heading "Server API") (wrapper Os))
   (client (lib ocsigen-start.client) (indexdoc doc/client.indexdoc) (heading "Client API") (wrapper Os)))


### PR DESCRIPTION
Part of an effort to make the Ocsigen documentation complete and well-formed on ocaml.org (picked up at the next release). Targets `deriving`.

`doc/index.mld` already is the package home page (it introduces Ocsigen Start and links to the introduction and the API). This:

- adds `@children_order intro` so the introduction appears before the API modules in the ocaml.org sidebar (instead of the alphabetical default);
- points the ocsigen.org landing (`doc/wodoc`) at `index.html`, and drops the now-redundant `Overview` nav entry (the home page is the landing).

## Verification

Standalone `odoc compile` of `index.mld` succeeds. Start is a client/server project built with odoc_driver (not plain `dune @doc`).