### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -8,8 +8,8 @@
 ;; switch; the manual (index/intro) is shared.
 (project ocsigen-start)
 (title Start)
-(pub /ocsigen-start)
-(odoc-driver ocsigen-start)
+(url-prefix /ocsigen-start)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (landing intro.html)
 
 ;; The shared manual nav (the two manual pages; the API module lists come from


### PR DESCRIPTION
wodoc master now ships a built-in default theme and renames the `pub` stanza to `url-prefix` (see ocsigen/wodoc). This keeps ocsigen-start's doc on the shared Ocsigen theme and adopts the new name:

- add `(css /css/style.css /css/ocsigen-odoc.css)` (wodoc's css default changed to a self-contained built-in theme, so this is now needed to keep the shared `/css/` look);
- rename `(pub …)` → `(url-prefix …)`.
- drop the now-redundant `(odoc-driver …)` — it is implied by `(client-server …)` in wodoc 1.0.

The doc CI tracks wodoc master, so no CI change is needed.