### PR TITLE
doc: link other Ocsigen projects with odoc references

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,8 +1,8 @@
 {0 Ocsigen Start}
 
 Ocsigen Start is a ready-to-use application skeleton for building
-client-server web and mobile applications with {{:https://ocsigen.org/eliom/}Eliom} and
-{{:https://ocsigen.org/ocsigen-toolkit/}Ocsigen Toolkit}. It ships with user management,
+client-server web and mobile applications with {{!/eliom/page-index}Eliom} and
+{{!/ocsigen-toolkit/page-index}Ocsigen Toolkit}. It ships with user management,
 notifications, a database schema and many code examples, so you can
 focus on your own features from day one.
 

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -213,13 +213,13 @@ connection forms, etc.
 - {!Os_services}:
   Eliom services pre-defined by Ocsigen Start. These produce the
   default user interface of the template.
-  See {{:https://ocsigen.org/eliom/latest/server-services.html}the Eliom manual page on services} for
+  See {{!/eliom/page-server-services}the Eliom manual page on services} for
   a general introduction to Eliom services.
 
 - {!Os_handlers}:
   The handlers (functions) that implement the services in
   {!Os_services}.
-  {{:https://ocsigen.org/eliom/latest/server-outputs.html}The Eliom manual page on service handlers}
+  {{!/eliom/page-server-outputs}The Eliom manual page on service handlers}
   explains how to implement handlers.
 
 - {!Os_session}:


### PR DESCRIPTION
Cross-project-links effort. Replace hardcoded `https://ocsigen.org/<project>/…` links (to Eliom and Ocsigen Toolkit) with odoc cross-package references: `{{!/eliom/page-index}}`, `{{!/eliom/page-server-services}}`, `{{!/eliom/page-server-outputs}}`, `{{!/ocsigen-toolkit/page-index}}`.

odoc resolves these on ocaml.org and wodoc rewrites them to the deployed docs on ocsigen.org (the `(hosted …)` table already lists these projects). The demo-application link (`/ocsigen-start/demo/`) and the tutorial link (`/tuto/…`, not an opam package) stay URLs. Pages compile with `odoc compile`.