### PR TITLE
doc: quote hyphenated page names in cross-project references

### DIFF
--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -213,13 +213,13 @@ connection forms, etc.
 - {!Os_services}:
   Eliom services pre-defined by Ocsigen Start. These produce the
   default user interface of the template.
-  See {{!/eliom/page-server-services}the Eliom manual page on services} for
+  See {{!/eliom/page-"server-services"}the Eliom manual page on services} for
   a general introduction to Eliom services.
 
 - {!Os_handlers}:
   The handlers (functions) that implement the services in
   {!Os_services}.
-  {{!/eliom/page-server-outputs}The Eliom manual page on service handlers}
+  {{!/eliom/page-"server-outputs"}The Eliom manual page on service handlers}
   explains how to implement handlers.
 
 - {!Os_session}:


### PR DESCRIPTION
odoc cannot parse a **hyphenated** page name in a path reference: `{{!/eliom/page-mobile-apps}}` produces "Unknown reference qualifier" and renders as plain text (no link). It must be quoted: `{{!/eliom/page-"mobile-apps"}}`. This quotes the hyphenated cross-project page references introduced earlier (they were silently broken). Verified: pages now compile with no reference-qualifier error.