### PR TITLE
doc: surface Os_connect_phone in the server API index

### DIFF
--- a/doc/indexdoc.server
+++ b/doc/indexdoc.server
@@ -1,6 +1,7 @@
 {2 Server API}
 
 {!modules:
+Os_connect_phone
 Os_current_user
 Os_date
 Os_db


### PR DESCRIPTION
`Os_connect_phone` is a public, user-facing module (SMS-based signup and phone-number management: `set_send_sms_handler`, `confirm_code_signup_no_connect`, ...) that was missing from `doc/indexdoc.server`, so it did not appear in the API navigation. Its odoc page is already generated. Doc-only change.

(`Os_comet` and `Os_core_db` are intentionally left out: they are low-level/internal; `Os_comet` is still reachable through the prose link in `intro.mld`, which resolves correctly.)