### PR TITLE
Adapt to Ocsigen Server 8: use stdlib Option

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -1,5 +1,6 @@
 ; Ocsigen Start manual pages (odoc .mld), compiled in place with the API by
 ; `dune build @doc` and installed with the package, so they appear on ocaml.org
 ; and resolve {{!page-X}} / {!Module} references against the API.
+
 (documentation
  (package ocsigen-start))

--- a/src/Os/current_user.eliom
+++ b/src/Os/current_user.eliom
@@ -78,7 +78,7 @@ module Opt = struct
   let get_current_user = get_current_user_option
 
   let get_current_userid () =
-    Eliom.Lib.Option.map User.userid_of_user (get_current_user_option ())
+    Option.map User.userid_of_user (get_current_user_option ())
 end]
 
 let%client _ = Session.get_current_userid_o := Opt.get_current_userid

--- a/src/Os/db.ml
+++ b/src/Os/db.ml
@@ -777,9 +777,7 @@ module User = struct
     then Lwt.fail_with "empty password"
     else
       full_transaction_block (fun dbh ->
-        let password_o =
-          Eliom.Lib.Option.map (fun p -> fst !pwd_crypt_ref p) password
-        in
+        let password_o = Option.map (fun p -> fst !pwd_crypt_ref p) password in
         let* userid =
           Lwt.bind
             (PGOCaml.bind

--- a/src/Os/db.ppx.ml
+++ b/src/Os/db.ppx.ml
@@ -146,9 +146,7 @@ module User = struct
     then Lwt.fail_with "empty password"
     else
       full_transaction_block (fun dbh ->
-        let password_o =
-          Eliom.Lib.Option.map (fun p -> fst !pwd_crypt_ref p) password
-        in
+        let password_o = Option.map (fun p -> fst !pwd_crypt_ref p) password in
         let* userid =
           Lwt.bind
             [%pgsql

--- a/src/Os/session.eliom
+++ b/src/Os/session.eliom
@@ -134,7 +134,7 @@ let disconnect_all
     match userid with
     | None -> (
         let uid = Eliom.State.get_volatile_data_session_group () in
-        try Eliom.Lib.Option.map Int64.of_string uid with Failure _ -> None)
+        try Option.map Int64.of_string uid with Failure _ -> None)
     | Some userid -> Some userid
   in
   match userid with
@@ -249,7 +249,7 @@ let check_allow_deny userid allow deny =
 let get_session () =
   let uids = Eliom.State.get_volatile_data_session_group () in
   let get_uid uid =
-    try Eliom.Lib.Option.map Int64.of_string uid with Failure _ -> None
+    try Option.map Int64.of_string uid with Failure _ -> None
   in
   let* uid =
     match get_uid uids with

--- a/src/Os/tips.eliom
+++ b/src/Os/tips.eliom
@@ -245,25 +245,25 @@ let%client
   let box = To_dom.of_element box in
   Dom.appendChild parent_node box;
   box##.style##.opacity := Js.string "0";
-  Eliom.Lib.Option.iter
+  Option.iter
     (fun v -> box##.style##.top := Js.string (Printf.sprintf "%ipx" v))
     top;
-  Eliom.Lib.Option.iter
+  Option.iter
     (fun v -> box##.style##.left := Js.string (Printf.sprintf "%ipx" v))
     left;
-  Eliom.Lib.Option.iter
+  Option.iter
     (fun v -> box##.style##.right := Js.string (Printf.sprintf "%ipx" v))
     right;
-  Eliom.Lib.Option.iter
+  Option.iter
     (fun v -> box##.style##.bottom := Js.string (Printf.sprintf "%ipx" v))
     bottom;
-  Eliom.Lib.Option.iter
+  Option.iter
     (fun v -> box##.style##.width := Js.string (Printf.sprintf "%ipx" v))
     width;
-  Eliom.Lib.Option.iter
+  Option.iter
     (fun v -> box##.style##.height := Js.string (Printf.sprintf "%ipx" v))
     height;
-  Eliom.Lib.Option.iter
+  Option.iter
     (fun a ->
        let bec = To_dom.of_element bec in
        let bec_size = bec##.offsetWidth in

--- a/src/Os/user.eliom
+++ b/src/Os/user.eliom
@@ -76,9 +76,7 @@ let%shared avatar_uri_of_avatar ?absolute_path avatar =
     ["avatars"; avatar]
 
 let%shared avatar_uri_of_user ?absolute_path user =
-  Eliom.Lib.Option.map
-    (avatar_uri_of_avatar ?absolute_path)
-    (avatar_of_user user)
+  Option.map (avatar_uri_of_avatar ?absolute_path) (avatar_of_user user)
 
 let%shared fullname_of_user user =
   String.concat " " [firstname_of_user user; lastname_of_user user]


### PR DESCRIPTION
Makes ocsigen-start build against Eliom 13 / Ocsigen Server 8.

- **Adapt to Server 8**: `Eliom.Lib.Option` (which re-exported the Ocsigen Server baselib `Option`, removed in Server 8) → stdlib `Option` (13 uses across 6 files; map/iter identical signatures).
- **Reformat doc/dune**: pre-existing one-line dune formatting drift that fails `lint-fmt`.

(`.ocamlformat` is already 0.29.0 here, so no version bump needed — unlike toolkit/eliom.)

Testing: `dune build @install` and `dune build @fmt` clean against eliom.13.0~dev (Ocsigen Server 8), with ocsigen-toolkit from its Server-8 branch.