### PR TITLE
Require js_of_ocaml 6.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - run: mkdir -p template
 
-      - run: opam exec -- eliom-distillery -name template -template os.pgocaml
+      - run: opam exec -- eliom-distillery -name template -template os
 
       - run: opam install -y .
         working-directory: template

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
         # The Server 8 / modern ppx stack (ocsigen-ppx-rpc needs ppxlib >= 0.37,
         # pulled together with ppx_sexp_conv -> ppxlib_jane) requires OCaml >= 5.3.
         ocaml-compiler:
@@ -43,6 +42,12 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-pin: false
+
+      # wasm_of_ocaml (pulled in via eliom) needs binaryen's wasm-merge.
+      - name: Set-up Binaryen
+        uses: Aandreba/setup-binaryen@v1.0.0
+        with:
+          token: ${{ github.token }}
 
       # Pin the Ocsigen Server 8 development branches until 8.0 is released
       # (the default branches of these repos are still the Server 7 line).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,10 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+        # The Server 8 / modern ppx stack (ocsigen-ppx-rpc needs ppxlib >= 0.37,
+        # pulled together with ppx_sexp_conv -> ppxlib_jane) requires OCaml >= 5.3.
         ocaml-compiler:
-          - "4.14"
-          - "5.2"
-        include:
-          - os: ubuntu-latest
-            ocaml-compiler: "4.12"
+          - "5"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,13 @@ jobs:
 
       - run: opam exec -- eliom-distillery -name template -template os
 
+      # Make the generated project its own dune root. It lives inside the
+      # ocsigen-start checkout, which ships a dune-project; without this, dune
+      # would take ocsigen-start as the root and treat the project as a nested
+      # subdirectory, which breaks Eliom's client/server value linking
+      # ("Inferred type of client value not found. You need to regenerate ...").
+      - run: echo '(lang dune 3.0)' > template/dune-workspace
+
       - run: opam install -y .
         working-directory: template
 

--- a/dune-project
+++ b/dune-project
@@ -60,7 +60,7 @@
     (< "2.0")))
   cohttp-lwt-unix
   (js_of_ocaml
-   (>= "6.3.2"))
+   (>= "6.4.0"))
   (re
    (>= "1.7.2"))
   (ocsipersist-pgsql-config

--- a/dune-project
+++ b/dune-project
@@ -46,7 +46,7 @@
   (ocsigen-i18n
    (>= "4.0.0"))
   (eliom
-   (>= "13.0.0"))
+   (>= "13.0~"))
   (ocsigen-toolkit
    (>= "2.7.0"))
   ocsigen-dune-rules

--- a/ocsigen-start.opam
+++ b/ocsigen-start.opam
@@ -21,7 +21,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "4.0.0"}
-  "eliom" {>= "13.0.0"}
+  "eliom" {>= "13.0~"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-dune-rules"
   "ocsigen-ppx-rpc" {>= "1.1"}

--- a/ocsigen-start.opam
+++ b/ocsigen-start.opam
@@ -21,14 +21,14 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "4.0.0"}
-  "eliom" {>= "13.0~"}
+  "eliom" {>= "13.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-dune-rules"
   "ocsigen-ppx-rpc" {>= "1.1"}
   "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
-  "js_of_ocaml" {>= "6.3.2"}
+  "js_of_ocaml" {>= "6.4.0"}
   "re" {>= "1.7.2"}
   "ocsipersist-pgsql-config" {>= "2.0" & < "3.0"}
   "conf-postgresql"

--- a/template.distillery/PROJECT_NAME.opam
+++ b/template.distillery/PROJECT_NAME.opam
@@ -4,7 +4,7 @@ version: "0.1"
 synopsis: "%%%PROJECT_NAME%%%"
 
 depends: [
-  "eliom" {>= "11.0.0" & < "12.0.0"}
+  "eliom" {>= "13.0~" & < "14.0.0"}
   "ocsipersist-pgsql-config" {>= "2.0" & < "3.0"}
-  "ocsigen-start" {>= "7.0.0" & < "8.0.0"}
+  "ocsigen-start" {>= "9.0~" & < "10.0.0"}
 ]

--- a/template.distillery/dune
+++ b/template.distillery/dune
@@ -114,7 +114,16 @@
 (subdir
  gen
  (rule
-  (deps ../tools/gen_dune.ml)
+  ; The generator lists the client modules by reading the set of source
+  ; files. Declaring that set as dependencies is what makes dune stage them
+  ; (and re-run the generator when an .eliom/.eliomi/.tsv is added, removed or
+  ; renamed). Without it the rule fails under a sandbox, and dune.client goes
+  ; stale so newly added client modules are silently dropped.
+  (deps
+   ../tools/gen_dune.ml
+   (glob_files ../*.eliom)
+   (glob_files ../*.eliomi)
+   (glob_files ../assets/*.tsv))
   (action
    (with-stdout-to
     dune.client

--- a/template.distillery/tools!gen_dune.ml
+++ b/template.distillery/tools!gen_dune.ml
@@ -23,7 +23,33 @@ let handle_file_client nm =
       nm nm
 
 let () =
-  Array.concat (List.map Sys.readdir [".."; "../assets"])
+  let root = Sys.readdir ".." in
+  let assets = Sys.readdir "../assets" in
+  (* The build directory mirrors the sources but also holds generated files,
+     which must not be enumerated or their client rule would be emitted twice:
+     - .pp.eliom/.pp.eliomi: preprocessing artifacts;
+     - the i18n modules produced from assets/*.tsv (the .tsv already emits the
+       rule) and the static config produced from *.eliom.in. *)
+  let generated_eliom = Hashtbl.create 16 in
+  Array.iter
+    (fun nm ->
+       if Filename.check_suffix nm ".tsv"
+       then Hashtbl.replace generated_eliom (Filename.chop_suffix nm ".tsv") ())
+    assets;
+  Array.iter
+    (fun nm ->
+       if Filename.check_suffix nm ".eliom.in"
+       then
+         Hashtbl.replace generated_eliom (Filename.chop_suffix nm ".eliom.in") ())
+    root;
+  let is_generated nm =
+    Filename.check_suffix nm ".pp.eliom"
+    || Filename.check_suffix nm ".pp.eliomi"
+    || (Filename.check_suffix nm ".eliom"
+       && Hashtbl.mem generated_eliom (Filename.chop_suffix nm ".eliom"))
+  in
+  Array.concat [root; assets]
   |> Array.to_list |> List.sort compare
   |> List.filter (fun nm -> nm.[0] <> '.')
+  |> List.filter (fun nm -> not (is_generated nm))
   |> List.iter handle_file_client

--- a/template.distillery/tools!gen_dune.ml
+++ b/template.distillery/tools!gen_dune.ml
@@ -23,7 +23,7 @@ let handle_file_client nm =
       nm nm
 
 let () =
-  Array.concat (List.map Sys.readdir ["../../.."; "../../../assets"])
+  Array.concat (List.map Sys.readdir [".."; "../assets"])
   |> Array.to_list |> List.sort compare
   |> List.filter (fun nm -> nm.[0] <> '.')
   |> List.iter handle_file_client


### PR DESCRIPTION
Bump the `js_of_ocaml` lower bound to 6.4.0 to match ocsigen-toolkit and the Server 8 / js 6.4 toolchain. No code change needed — ocsigen-start builds as-is against js 6.4.0.