### PR TITLE
ci(doc): cache the opam switch to skip recompiling the dependency tree

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -50,20 +50,42 @@ jobs:
         with:
           token: ${{ github.token }}
 
-      - name: Install dependencies
+      # The bottleneck of this job is compiling the dependency tree (incl.
+      # wasm_of_ocaml) plus wodoc and odoc from source; setup-ocaml only caches the
+      # base switch (the compiler), so they recompiled on every push. Cache the
+      # whole _opam switch keyed on ocsigen-start.opam (the dep set) and wodoc's HEAD
+      # commit. On a cache hit the deps and wodoc are restored and only ocsigen-start
+      # itself is (re)built below; the key changes -- and the deps/wodoc rebuild
+      # once -- only when ocsigen-start.opam or wodoc move.
+      - name: Resolve wodoc HEAD commit
+        id: wodoc
+        run: echo "sha=$(git ls-remote https://github.com/ocsigen/wodoc.git HEAD | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the opam switch (deps + wodoc)
+        id: switch-cache
+        uses: actions/cache@v4
+        with:
+          path: _opam
+          key: opam-switch-${{ runner.os }}-ocaml5.4.0-${{ hashFiles('*.opam') }}-wodoc-${{ steps.wodoc.outputs.sha }}
+
+      - name: Install dependencies and wodoc
+        # Cache miss only: build the dependency tree and wodoc once, then re-cache.
+        if: steps.switch-cache.outputs.cache-hit != 'true'
         run: |
-          # Install ocsigen-start (from the ref being built) so odoc_driver
-          # documents these sources. It is installed WITHOUT --with-doc: its server
-          # and client libraries share module names, so building its own @doc
-          # collides ("Multiple rules for .../Os_*/index.html"). wodoc builds the
-          # docs via `odoc_driver --remap` instead.
           opam install . --deps-only --with-doc
-          opam install .
           # wodoc themes the pages. Its opam pin-depends pulls odoc / odoc-driver
           # from the balat/odoc fork (the cross-library link fix, not yet upstream),
           # so we do NOT pin odoc ourselves here.
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
           opam install wodoc
+
+      - name: Install ocsigen-start
+        # Always: ocsigen-start's own sources change on every push, so odoc_driver must
+        # document the freshly-built package. It is installed WITHOUT --with-doc:
+        # its server and client libraries share module names, so building its own
+        # @doc collides ("Multiple rules for .../Os_*/index.html"). wodoc builds
+        # the docs via `odoc_driver --remap` instead.
+        run: opam install .
 
       - name: Build documentation (dev)
         # wodoc build runs `odoc_driver ocsigen-start --remap` on the installed


### PR DESCRIPTION
## Problem

The `Documentation` workflow recompiles the whole dependency tree (incl. wasm_of_ocaml) plus wodoc and odoc from source on **every push** (several minutes); `setup-ocaml@v3` only caches the base switch (the compiler).

## Fix

Cache the whole `_opam` switch with `actions/cache`, keyed on `*.opam` (the dependency set) and wodoc's resolved HEAD commit. The install is split:

- **Install dependencies and wodoc** — cache miss only (deps tree + wodoc).
- **Install <project>** — **always**: the project's own sources change every push, so `opam install .` re-syncs the local pin and rebuilds it for `odoc_driver --remap` to document. Only the project recompiles on the hot path, not its dependencies.

The cache rebuilds once when an `*.opam` file or wodoc's HEAD move.

Same approach validated on ocsigen.github.io and ocsigenserver (each ~5 min → ~1 min).

> ⚠️ This project pulls wasm_of_ocaml; if a validation run hits the current `Aandreba/setup-binaryen`/wasm_of_ocaml build breakage (see ocsigen/eliom#894), that is **independent of this change** and would block the next master push too.
> The `release` job (manual, infrequent) is left as-is.