### PR TITLE
template: make the client-module generator work under a dune sandbox

### DIFF
--- a/template.distillery/dune
+++ b/template.distillery/dune
@@ -114,7 +114,16 @@
 (subdir
  gen
  (rule
-  (deps ../tools/gen_dune.ml)
+  ; The generator lists the client modules by reading the set of source
+  ; files. Declaring that set as dependencies is what makes dune stage them
+  ; (and re-run the generator when an .eliom/.eliomi/.tsv is added, removed or
+  ; renamed). Without it the rule fails under a sandbox, and dune.client goes
+  ; stale so newly added client modules are silently dropped.
+  (deps
+   ../tools/gen_dune.ml
+   (glob_files ../*.eliom)
+   (glob_files ../*.eliomi)
+   (glob_files ../assets/*.tsv))
   (action
    (with-stdout-to
     dune.client

--- a/template.distillery/tools!gen_dune.ml
+++ b/template.distillery/tools!gen_dune.ml
@@ -23,7 +23,7 @@ let handle_file_client nm =
       nm nm
 
 let () =
-  Array.concat (List.map Sys.readdir ["../../.."; "../../../assets"])
+  Array.concat (List.map Sys.readdir [".."; "../assets"])
   |> Array.to_list |> List.sort compare
   |> List.filter (fun nm -> nm.[0] <> '.')
   |> List.iter handle_file_client


### PR DESCRIPTION
## Problem

Building a project generated from the `os` template fails during the client-module generation step:

```
Exception: Sys_error "../../../assets: No such file or directory".
```

The generator (`tools/gen_dune.ml`) enumerates the project sources by reading `../../..` and `../../../assets`. From the `gen` rule's build directory those paths climb *out* of `_build` into the real source tree. It happens to work when the rule runs unsandboxed, but breaks as soon as dune sandboxes the rule (as in CI) or the project has an extra directory level, because the paths no longer resolve.

## Fix

- `gen` is a direct subdirectory of the project root, so read the sources from `..` and `../assets` instead of `../../..`.
- Declare the `.eliom` / `.eliomi` / `.tsv` sources as dependencies of the `gen` rule (`glob_files`), so dune stages them into the sandbox and re-runs the generator when a client module is added, removed or renamed.

Both parts are required: the path fix alone still fails under a sandbox (the sources are not staged), and declaring the deps alone does not help while the generator reads the wrong paths.

## Verification

Reproduced the exact CI failure with `dune build --sandbox=copy` on a freshly distilled project, then confirmed the fix on the same stack (js_of_ocaml 6.4, Eliom 13 dev, Toolkit 5 dev, Start dev): a regenerated project builds `gen/dune.client` cleanly under `--sandbox=copy`.

The same fix is applied upstream in `os_template`.