### PR TITLE
template: skip generated files in the client-module generator

### DIFF
--- a/template.distillery/tools!gen_dune.ml
+++ b/template.distillery/tools!gen_dune.ml
@@ -23,7 +23,33 @@ let handle_file_client nm =
       nm nm
 
 let () =
-  Array.concat (List.map Sys.readdir [".."; "../assets"])
+  let root = Sys.readdir ".." in
+  let assets = Sys.readdir "../assets" in
+  (* The build directory mirrors the sources but also holds generated files,
+     which must not be enumerated or their client rule would be emitted twice:
+     - .pp.eliom/.pp.eliomi: preprocessing artifacts;
+     - the i18n modules produced from assets/*.tsv (the .tsv already emits the
+       rule) and the static config produced from *.eliom.in. *)
+  let generated_eliom = Hashtbl.create 16 in
+  Array.iter
+    (fun nm ->
+       if Filename.check_suffix nm ".tsv"
+       then Hashtbl.replace generated_eliom (Filename.chop_suffix nm ".tsv") ())
+    assets;
+  Array.iter
+    (fun nm ->
+       if Filename.check_suffix nm ".eliom.in"
+       then
+         Hashtbl.replace generated_eliom (Filename.chop_suffix nm ".eliom.in") ())
+    root;
+  let is_generated nm =
+    Filename.check_suffix nm ".pp.eliom"
+    || Filename.check_suffix nm ".pp.eliomi"
+    || (Filename.check_suffix nm ".eliom"
+       && Hashtbl.mem generated_eliom (Filename.chop_suffix nm ".eliom"))
+  in
+  Array.concat [root; assets]
   |> Array.to_list |> List.sort compare
   |> List.filter (fun nm -> nm.[0] <> '.')
+  |> List.filter (fun nm -> not (is_generated nm))
   |> List.iter handle_file_client


### PR DESCRIPTION
Follow-up to #727.

That PR made the client-module generator read the build directory (`..`) instead of climbing out of `_build` via `../../..`, which fixed the `Sys_error "../../../assets"` failure. But the build directory mirrors the sources *plus* generated files, and the generator then enumerated those too, emitting a client rule twice for the same target:

```
Error: Multiple rules generated for .../client/<project>_i18n.ml
- gen/dune.client:157
- gen/dune.client:153
```

(and likewise a `.pp.mli` clashing with the client `dune`).

The generated files are:
- `.pp.eliom` / `.pp.eliomi` preprocessing artifacts;
- the i18n `.eliom` modules produced from `assets/*.tsv` (the `.tsv` already emits the rule);
- the static config `.eliom` produced from `*.eliom.in`.

This filters them out so only real sources are enumerated, reconstructing exactly what the old `../../..` (source-tree) read produced.

## Verification

Full build with the database available (`make db-create db-schema` + `dune build @check @install`) passes on a distilled `os` project and on `os_template` directly, on the Server 8 / js_of_ocaml 6.4 stack. The generated `dune.client` has one rule per module, no `.pp.mli`, no static-config client rule.